### PR TITLE
Wire dispute and reputation modules to JobRegistry

### DIFF
--- a/migrations/3_wire_protocol.js
+++ b/migrations/3_wire_protocol.js
@@ -28,6 +28,8 @@ module.exports = async function (_deployer, network, accounts) {
 
   await staking.setJobRegistry(jr.address);
   await feePool.setJobRegistry(jr.address);
+  await dispute.setJobRegistry(jr.address);
+  await reputation.setJobRegistry(jr.address);
 
   await jr.setTimings(params.commitWindow, params.revealWindow, params.disputeWindow);
   await jr.setThresholds(

--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -18,12 +18,24 @@ module.exports = async function (callback) {
       }
     };
 
-    expectEq(modules.identity, (await IdentityRegistry.deployed()).address, 'identity');
-    expectEq(modules.staking, (await StakeManager.deployed()).address, 'staking');
-    expectEq(modules.validation, (await ValidationModule.deployed()).address, 'validation');
-    expectEq(modules.dispute, (await DisputeModule.deployed()).address, 'dispute');
-    expectEq(modules.reputation, (await ReputationEngine.deployed()).address, 'reputation');
-    expectEq(modules.feePool, (await FeePool.deployed()).address, 'feePool');
+    const identity = await IdentityRegistry.deployed();
+    const staking = await StakeManager.deployed();
+    const validation = await ValidationModule.deployed();
+    const dispute = await DisputeModule.deployed();
+    const reputation = await ReputationEngine.deployed();
+    const feePool = await FeePool.deployed();
+
+    expectEq(modules.identity, identity.address, 'identity');
+    expectEq(modules.staking, staking.address, 'staking');
+    expectEq(modules.validation, validation.address, 'validation');
+    expectEq(modules.dispute, dispute.address, 'dispute');
+    expectEq(modules.reputation, reputation.address, 'reputation');
+    expectEq(modules.feePool, feePool.address, 'feePool');
+
+    expectEq(await staking.jobRegistry(), jr.address, 'staking.jobRegistry');
+    expectEq(await feePool.jobRegistry(), jr.address, 'feePool.jobRegistry');
+    expectEq(await dispute.jobRegistry(), jr.address, 'dispute.jobRegistry');
+    expectEq(await reputation.jobRegistry(), jr.address, 'reputation.jobRegistry');
 
     const thresholds = await jr.thresholds();
     if (Number(thresholds.feeBps) !== params.feeBps) {

--- a/test/jobRegistry.test.js
+++ b/test/jobRegistry.test.js
@@ -50,6 +50,13 @@ contract('JobRegistry', (accounts) => {
     assert.strictEqual(modules.feePool, this.feePool.address);
   });
 
+  it('wires dependent modules back to the registry', async function () {
+    assert.strictEqual(await this.stakeManager.jobRegistry(), this.jobRegistry.address);
+    assert.strictEqual(await this.feePool.jobRegistry(), this.jobRegistry.address);
+    assert.strictEqual(await this.dispute.jobRegistry(), this.jobRegistry.address);
+    assert.strictEqual(await this.reputation.jobRegistry(), this.jobRegistry.address);
+  });
+
   it('runs through a happy path lifecycle', async function () {
     const stakeAmount = web3.utils.toBN('1000');
     await this.stakeManager.deposit(stakeAmount, { from: worker });


### PR DESCRIPTION
## Summary
- wire DisputeModule and ReputationEngine to the JobRegistry during migrations
- assert registry wiring in the verify script and unit tests to catch regressions

## Testing
- GOV_SAFE=0x516Dbd71Df30e4D6Fd44E0d53D412f4725287920 npx truffle migrate --reset --network development
- GOV_SAFE=0xdD2F9a23fce87abfEF96c8F2B512A7436Eed79AB TRUFFLE_TEST=true npx truffle test test/jobRegistry.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cc8ef45f4483338691cc288a25ee2b