### PR TITLE
Document GOV_SAFE secret for testnet deploy workflow

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -22,6 +22,8 @@ jobs:
         env:
           MNEMONIC: ${{ secrets.MNEMONIC }}
           RPC_SEPOLIA: ${{ secrets.RPC_SEPOLIA }}
+          GOV_SAFE: ${{ secrets.GOV_SAFE }}
+          TIMELOCK_ADDR: ${{ secrets.TIMELOCK_ADDR }}
       - run: NETWORK=${{ github.event.inputs.network || 'sepolia' }} npm run verify:sepolia
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ npm run verify:sepolia
 npm run export:artifacts
 ```
 
+### GitHub Actions secrets
+
+Deployments from CI require the following repository secrets so migrations can transfer ownership correctly:
+
+- `MNEMONIC` — Deployer account seed phrase.
+- `RPC_SEPOLIA` — HTTPS RPC endpoint for Sepolia.
+- `ETHERSCAN_API_KEY` — API key for contract verification.
+- `GOV_SAFE` — Destination Safe that receives ownership of deployed contracts.
+- `TIMELOCK_ADDR` — Optional timelock admin that will be configured on modules supporting it.
+
 ## Governance
 
 All privileged ownership is transferred to a Safe and timelock during migrations. See `/audit/threat-model.md` for expectations and emergency guidance.


### PR DESCRIPTION
## Summary
- pass GOV_SAFE and optional TIMELOCK_ADDR secrets into the testnet migration step
- document the required GitHub Actions secrets for CI-based deployments

## Testing
- not run (documentation and workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68ccd1a2636083339589e6cbea56ba47