### PR TITLE
Respect network when exporting artifacts

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -27,7 +27,10 @@ jobs:
       - run: NETWORK=${{ github.event.inputs.network || 'sepolia' }} npm run verify:sepolia
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-      - run: NETWORK=${{ github.event.inputs.network || 'sepolia' }} npm run export:artifacts
+      - name: Export deployment artifacts
+        run: npm run export:artifacts
+        env:
+          NETWORK: ${{ github.event.inputs.network || 'sepolia' }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: artifacts-public

--- a/scripts/export-artifacts-runner.js
+++ b/scripts/export-artifacts-runner.js
@@ -2,6 +2,8 @@ const { spawn } = require('child_process');
 const path = require('path');
 
 async function run() {
+  const network = process.env.NETWORK || 'development';
+
   const ganache = spawn(path.join('node_modules', '.bin', 'ganache'), [
     '--chain.networkId',
     '5777',
@@ -16,7 +18,7 @@ async function run() {
   await wait(3000);
 
   await new Promise((resolve, reject) => {
-    const migrate = spawn('npx', ['truffle', 'migrate', '--reset', '--network', 'development'], {
+    const migrate = spawn('npx', ['truffle', 'migrate', '--reset', '--network', network], {
       stdio: 'inherit',
       env: { ...process.env, TRUFFLE_TEST: 'true' },
     });
@@ -30,9 +32,9 @@ async function run() {
   });
 
   await new Promise((resolve, reject) => {
-    const exec = spawn('npx', ['truffle', 'exec', 'scripts/export-addresses.js', '--network', 'development'], {
+    const exec = spawn('npx', ['truffle', 'exec', 'scripts/export-addresses.js', '--network', network], {
       stdio: 'inherit',
-      env: { ...process.env, NETWORK: 'development' },
+      env: { ...process.env, NETWORK: network },
     });
     exec.on('exit', (code) => {
       if (code === 0) {


### PR DESCRIPTION
## Summary
- allow export-artifacts-runner to respect the NETWORK environment when running truffle commands
- update the deploy-testnet workflow to pass the chosen network into the export step so addresses write to the correct file

## Testing
- NETWORK=development npm run export:artifacts

------
https://chatgpt.com/codex/tasks/task_e_68ccd2afe1208333be0c6cf04dcc26d7