### PR TITLE
Improve development automation reliability

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/h"
+
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/h"
+
+npx --no-install lint-staged

--- a/scripts/export-artifacts-runner.js
+++ b/scripts/export-artifacts-runner.js
@@ -1,66 +1,32 @@
-const { spawn } = require('child_process');
 const path = require('path');
-
-function wait(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function runCommand(command, args, options = {}) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: 'inherit', ...options });
-    child.on('exit', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
-      }
-    });
-    child.on('error', (error) => reject(error));
-  });
-}
-
-async function stopProcess(proc) {
-  if (!proc || proc.killed) {
-    return;
-  }
-
-  await new Promise((resolve) => {
-    proc.once('exit', resolve);
-    proc.kill('SIGINT');
-  });
-}
+const { withGanache } = require('./utils/ganache');
+const { runCommand } = require('./utils/runCommand');
 
 async function run() {
   const network = process.env.NETWORK || 'development';
-  const ganache = spawn(path.join('node_modules', '.bin', 'ganache'), [
-    '--chain.networkId',
-    '5777',
-    '--wallet.totalAccounts',
-    '10',
-  ], {
-    stdio: 'inherit',
-  });
 
-  try {
-    await wait(3000);
+  await withGanache(async () => {
+    const sharedEnv = {
+      ...process.env,
+      NETWORK: network,
+      TRUFFLE_TEST: process.env.TRUFFLE_TEST || 'true',
+    };
 
     await runCommand('npx', ['truffle', 'migrate', '--reset', '--network', network], {
-      env: { ...process.env, TRUFFLE_TEST: 'true' },
+      env: sharedEnv,
     });
 
-    await runCommand('npx', ['truffle', 'exec', 'scripts/export-addresses.js', '--network', network], {
+    await runCommand(
+      'npx',
+      ['truffle', 'exec', path.join('scripts', 'export-addresses.js'), '--network', network],
+      { env: sharedEnv }
+    );
+
+    await runCommand('node', [path.join('scripts', 'export-abis.js')], {
       env: { ...process.env, NETWORK: network },
+      shell: false,
     });
-
-    await runCommand('node', ['scripts/export-abis.js'], {
-      env: process.env,
-    });
-  } catch (error) {
-    console.error(error);
-    process.exitCode = 1;
-  } finally {
-    await stopProcess(ganache);
-  }
+  });
 }
 
 run().catch((error) => {

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,20 +1,13 @@
-const { spawn } = require('child_process');
-const path = require('path');
+const { withGanache } = require('./utils/ganache');
+const { runCommand } = require('./utils/runCommand');
 
 async function run() {
-  const ganache = spawn(
-    path.join('node_modules', '.bin', 'ganache'),
-    ['--chain.networkId', '5777', '--wallet.totalAccounts', '10'],
-    { stdio: ['ignore', 'inherit', 'inherit'] }
-  );
-
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-
-  const truffle = spawn('npx', ['truffle', 'test', '--show-events'], { stdio: 'inherit' });
-
-  truffle.on('exit', (code) => {
-    ganache.kill('SIGINT');
-    process.exit(code);
+  await runCommand('npx', ['truffle', 'compile', '--all']);
+  await withGanache(async () => {
+    await runCommand('npx', ['truffle', 'test', '--show-events']);
+  }, {
+    networkId: 5777,
+    totalAccounts: 10,
   });
 }
 

--- a/scripts/utils/ganache.js
+++ b/scripts/utils/ganache.js
@@ -1,0 +1,203 @@
+const { spawn } = require('child_process');
+const net = require('net');
+const path = require('path');
+
+const DEFAULT_PORT = 8545;
+const DEFAULT_NETWORK_ID = 5777;
+const DEFAULT_TOTAL_ACCOUNTS = 10;
+const WAIT_INTERVAL_MS = 250;
+const WAIT_ATTEMPTS = 40;
+const STOP_TIMEOUT_MS = 5000;
+
+function ganacheBinary() {
+  if (process.env.GANACHE_BIN) {
+    return process.env.GANACHE_BIN;
+  }
+  const binaryName = process.platform === 'win32' ? 'ganache.cmd' : 'ganache';
+  return path.join(__dirname, '..', '..', 'node_modules', '.bin', binaryName);
+}
+
+async function isPortAvailable(port, host = '127.0.0.1') {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once('error', () => {
+      server.close(() => resolve(false));
+    });
+    server.listen(port, host, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function findFreePort(preferredPort) {
+  if (preferredPort && (await isPortAvailable(preferredPort))) {
+    return preferredPort;
+  }
+
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForPort(port, host = '127.0.0.1') {
+  for (let attempt = 0; attempt < WAIT_ATTEMPTS; attempt += 1) {
+    const connected = await new Promise((resolve) => {
+      const socket = net.createConnection({ port, host }, () => {
+        socket.end();
+        resolve(true);
+      });
+      socket.on('error', () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+
+    if (connected) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, WAIT_INTERVAL_MS));
+  }
+
+  throw new Error(`Timed out waiting for Ganache to listen on ${host}:${port}`);
+}
+
+async function startGanache(options = {}) {
+  const {
+    port: preferredPort = Number(process.env.GANACHE_PORT) || DEFAULT_PORT,
+    networkId = DEFAULT_NETWORK_ID,
+    totalAccounts = DEFAULT_TOTAL_ACCOUNTS,
+    chainId,
+    extraArgs = [],
+  } = options;
+
+  const port = await findFreePort(preferredPort);
+  const args = [
+    '--server.port',
+    String(port),
+    '--chain.networkId',
+    String(networkId),
+    '--wallet.totalAccounts',
+    String(totalAccounts),
+    '--wallet.deterministic',
+    ...extraArgs,
+  ];
+
+  if (chainId) {
+    args.push('--chain.chainId', String(chainId));
+  }
+
+  const child = spawn(ganacheBinary(), args, {
+    stdio: 'inherit',
+    env: { ...process.env, GANACHE_PORT: String(port) },
+  });
+
+  let settled = false;
+
+  return new Promise((resolve, reject) => {
+    const onError = (error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
+
+    const onExit = (code, signal) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Ganache exited before it became ready (code=${code}, signal=${signal})`));
+      }
+    };
+
+    child.once('error', onError);
+    child.once('exit', onExit);
+
+    waitForPort(port)
+      .then(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        child.off('error', onError);
+        child.off('exit', onExit);
+        resolve({ process: child, port });
+      })
+      .catch((error) => {
+        if (!settled) {
+          settled = true;
+          child.off('error', onError);
+          child.off('exit', onExit);
+          reject(error);
+        }
+      });
+  });
+}
+
+async function stopGanache(child) {
+  if (!child || child.killed) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    let settled = false;
+
+    const cleanup = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      child.removeAllListeners('exit');
+      resolve();
+    };
+
+    child.once('exit', cleanup);
+
+    const timeout = setTimeout(() => {
+      if (child.killed) {
+        cleanup();
+        return;
+      }
+      child.kill('SIGKILL');
+    }, STOP_TIMEOUT_MS);
+
+    child.once('exit', () => {
+      clearTimeout(timeout);
+      cleanup();
+    });
+
+    if (!child.kill('SIGINT')) {
+      clearTimeout(timeout);
+      cleanup();
+    }
+  });
+}
+
+async function withGanache(task, options) {
+  const { process: child, port } = await startGanache(options);
+  const previousPort = process.env.GANACHE_PORT;
+  process.env.GANACHE_PORT = String(port);
+
+  try {
+    return await task({ port, process: child });
+  } finally {
+    if (previousPort === undefined) {
+      delete process.env.GANACHE_PORT;
+    } else {
+      process.env.GANACHE_PORT = previousPort;
+    }
+    await stopGanache(child);
+  }
+}
+
+module.exports = {
+  startGanache,
+  stopGanache,
+  withGanache,
+  waitForPort,
+};

--- a/scripts/utils/runCommand.js
+++ b/scripts/utils/runCommand.js
@@ -1,0 +1,34 @@
+const { spawn } = require('child_process');
+
+const isWindows = process.platform === 'win32';
+
+function normalizeOptions(options = {}) {
+  const env = { ...process.env, ...(options.env || {}) };
+  const merged = {
+    stdio: 'inherit',
+    shell: options.shell ?? isWindows,
+    ...options,
+    env,
+  };
+
+  return merged;
+}
+
+function runCommand(command, args = [], options = {}) {
+  const child = spawn(command, args, normalizeOptions(options));
+
+  return new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        const description =
+          code === null ? `terminated by signal ${signal}` : `exited with code ${code}`;
+        reject(new Error(`${command} ${args.join(' ')} ${description}`));
+      }
+    });
+  });
+}
+
+module.exports = { runCommand };

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -2,12 +2,13 @@ require('dotenv').config();
 const HDWalletProvider = require('@truffle/hdwallet-provider');
 
 const { MNEMONIC, RPC_MAINNET, RPC_SEPOLIA, ETHERSCAN_API_KEY } = process.env;
+const GANACHE_PORT = Number(process.env.GANACHE_PORT || 8545);
 
 module.exports = {
   plugins: ['truffle-plugin-verify', 'solidity-coverage'],
   api_keys: { etherscan: ETHERSCAN_API_KEY },
   networks: {
-    development: { host: '127.0.0.1', port: 8545, network_id: '*' },
+    development: { host: '127.0.0.1', port: GANACHE_PORT, network_id: '*' },
     sepolia: {
       provider: () => new HDWalletProvider(MNEMONIC, RPC_SEPOLIA),
       network_id: 11155111,


### PR DESCRIPTION
## Summary
- introduce reusable Ganache lifecycle helper and command runner utilities
- update test and artifact workflows to use the shared helpers and compile before execution
- enable husky lint-staged/commitlint hooks and allow overriding the local Ganache port in Truffle config

## Testing
- npm run test
- npm run coverage
- npm run export:artifacts

------
https://chatgpt.com/codex/tasks/task_e_68ccecba2cfc8333b58b507bc5b80882