### PR TITLE
Fix Echidna workflow command formatting

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -52,7 +52,9 @@ jobs:
           solc-select install 0.8.20
           solc-select use 0.8.20
       - name: Run Echidna smoke
-        run: >-
-          echidna-test ./contracts/core/EchidnaJobRegistryInvariants.sol \
-          --contract EchidnaJobRegistryInvariants \
-          --config tools/echidna.yaml
+        run: |
+          set -euxo pipefail
+          echidna-test \
+            ./contracts/core/EchidnaJobRegistryInvariants.sol \
+            --contract EchidnaJobRegistryInvariants \
+            --config tools/echidna.yaml


### PR DESCRIPTION
## Summary
- ensure the Echidna smoke test command is executed with proper multi-line formatting
- add shell strict mode to surface failures in the Echidna workflow step

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd625de91883338492449ac434c2bf