### PR TITLE
Update verify wiring script to use modules struct

### DIFF
--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -11,9 +11,22 @@ const params = require('../config/params.json');
 module.exports = async function (callback) {
   try {
     const jr = await JobRegistry.deployed();
+    const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
     const modules = await jr.modules();
+    const actual = {
+      identity: modules.identity,
+      staking: modules.staking,
+      validation: modules.validation,
+      dispute: modules.dispute,
+      reputation: modules.reputation,
+      feePool: modules.feePool,
+    };
     const expectEq = (lhs, rhs, label) => {
-      if (lhs.toLowerCase() !== rhs.toLowerCase()) {
+      const left = lhs.toLowerCase();
+      if (left === ZERO_ADDRESS) {
+        throw new Error(`Zero address for ${label}`);
+      }
+      if (left !== rhs.toLowerCase()) {
         throw new Error(`Mismatch for ${label}: ${lhs} !== ${rhs}`);
       }
     };
@@ -25,12 +38,12 @@ module.exports = async function (callback) {
     const reputation = await ReputationEngine.deployed();
     const feePool = await FeePool.deployed();
 
-    expectEq(modules.identity, identity.address, 'identity');
-    expectEq(modules.staking, staking.address, 'staking');
-    expectEq(modules.validation, validation.address, 'validation');
-    expectEq(modules.dispute, dispute.address, 'dispute');
-    expectEq(modules.reputation, reputation.address, 'reputation');
-    expectEq(modules.feePool, feePool.address, 'feePool');
+    expectEq(actual.identity, identity.address, 'identity');
+    expectEq(actual.staking, staking.address, 'staking');
+    expectEq(actual.validation, validation.address, 'validation');
+    expectEq(actual.dispute, dispute.address, 'dispute');
+    expectEq(actual.reputation, reputation.address, 'reputation');
+    expectEq(actual.feePool, feePool.address, 'feePool');
 
     expectEq(await staking.jobRegistry(), jr.address, 'staking.jobRegistry');
     expectEq(await feePool.jobRegistry(), jr.address, 'feePool.jobRegistry');

--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -13,14 +13,6 @@ module.exports = async function (callback) {
     const jr = await JobRegistry.deployed();
     const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
     const modules = await jr.modules();
-    const actual = {
-      identity: modules.identity,
-      staking: modules.staking,
-      validation: modules.validation,
-      dispute: modules.dispute,
-      reputation: modules.reputation,
-      feePool: modules.feePool,
-    };
     const expectEq = (lhs, rhs, label) => {
       const left = lhs.toLowerCase();
       if (left === ZERO_ADDRESS) {
@@ -38,12 +30,16 @@ module.exports = async function (callback) {
     const reputation = await ReputationEngine.deployed();
     const feePool = await FeePool.deployed();
 
-    expectEq(actual.identity, identity.address, 'identity');
-    expectEq(actual.staking, staking.address, 'staking');
-    expectEq(actual.validation, validation.address, 'validation');
-    expectEq(actual.dispute, dispute.address, 'dispute');
-    expectEq(actual.reputation, reputation.address, 'reputation');
-    expectEq(actual.feePool, feePool.address, 'feePool');
+    [
+      ['identity', modules.identity, identity.address],
+      ['staking', modules.staking, staking.address],
+      ['validation', modules.validation, validation.address],
+      ['dispute', modules.dispute, dispute.address],
+      ['reputation', modules.reputation, reputation.address],
+      ['feePool', modules.feePool, feePool.address],
+    ].forEach(([label, actual, expected]) => {
+      expectEq(actual, expected, label);
+    });
 
     expectEq(await staking.jobRegistry(), jr.address, 'staking.jobRegistry');
     expectEq(await feePool.jobRegistry(), jr.address, 'feePool.jobRegistry');


### PR DESCRIPTION
## Summary
- load the JobRegistry modules struct once and extract module addresses from it
- add zero-address guarding while comparing module wiring against expected deployments

## Testing
- npx truffle exec scripts/verify-wiring.js --network development *(fails: no node running at 127.0.0.1:8545)*

------
https://chatgpt.com/codex/tasks/task_e_68cd72d2e35483338d5bb773b555251a