### PR TITLE
Verify module ownership matches job registry

### DIFF
--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -23,6 +23,9 @@ module.exports = async function (callback) {
       }
     };
 
+    const owner = await jobRegistry.owner();
+    expectEq(owner, owner, 'jobRegistry.owner');
+
     const identity = await IdentityRegistry.deployed();
     const staking = await StakeManager.deployed();
     const validation = await ValidationModule.deployed();
@@ -40,6 +43,20 @@ module.exports = async function (callback) {
     ].forEach(([label, actual, expected]) => {
       expectEq(actual, expected, label);
     });
+
+    await Promise.all(
+      [
+        ['identity.owner', identity.owner()],
+        ['staking.owner', staking.owner()],
+        ['validation.owner', validation.owner()],
+        ['dispute.owner', dispute.owner()],
+        ['reputation.owner', reputation.owner()],
+        ['feePool.owner', feePool.owner()],
+      ].map(async ([label, valuePromise]) => {
+        const value = await valuePromise;
+        expectEq(value, owner, label);
+      })
+    );
 
     expectEq(await staking.jobRegistry(), jobRegistry.address, 'staking.jobRegistry');
     expectEq(await feePool.jobRegistry(), jobRegistry.address, 'feePool.jobRegistry');


### PR DESCRIPTION
## Summary
- capture the JobRegistry owner when verifying wiring
- ensure each module owner matches the JobRegistry owner using the existing equality helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd7b4b1a14833380b3453a25a5475b