### PR TITLE
Make wire:verify network configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ npm run export:artifacts
 
 `npm run export:artifacts` performs a deterministic local migration, exports network-specific addresses, and generates sanitized ABI bundles under `artifacts-public/`. Use `npm run export:abis` when you only need to refresh the ABI manifest after a compile.
 
+## Verify wiring
+
+Run the wiring checker to confirm deployed contract addresses match the expected configuration:
+
+```bash
+npm run wire:verify
+```
+
+The script defaults to the local development network. Override it by setting `NETWORK` before invoking the command, for example:
+
+```bash
+NETWORK=sepolia npm run wire:verify
+```
+
 ### GitHub Actions secrets
 
 Deployments from CI require the following repository secrets so migrations can transfer ownership correctly:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "verify:sepolia": "truffle run verify IdentityRegistry StakeManager FeePool ValidationModule DisputeModule ReputationEngine CertificateNFT JobRegistry --network sepolia",
     "export:abis": "node scripts/export-abis.js",
     "export:artifacts": "node scripts/export-artifacts-runner.js",
-    "wire:verify": "truffle exec scripts/verify-wiring.js",
+    "wire:verify": "truffle exec scripts/verify-wiring.js --network ${NETWORK:-development}",
     "namehash": "node scripts/compute-namehash.js",
     "prepare": "husky install",
     "ganache:test": "node scripts/run-tests.js"


### PR DESCRIPTION
## Summary
- forward the `NETWORK` environment variable to the `wire:verify` script with a development default
- document how to run the wiring verification script and override the target network

## Testing
- NETWORK=sepolia MNEMONIC="test test test test test test test test test test test junk" RPC_SEPOLIA=http://127.0.0.1:8545 npm run wire:verify *(fails: missing build/contracts artifacts, but shows Truffle using the sepolia network)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8aa0ce908333be179ab9c564cbb8