### PR TITLE
Adjust workflow permissions for artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit permissions block in the CI workflow so the upload-artifact step has write access

## Testing
- not run (cannot execute GitHub Actions workflow in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cd93146d6483338f6885c24757e68d