### PR TITLE
Handle missing LCOV line metrics in coverage checker

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -65,7 +65,11 @@ function checkCoverage(options = {}) {
 
   const content = fs.readFileSync(lcovPath, 'utf8');
   const { totalLines, coveredLines } = aggregateLcov(content);
-  const pct = totalLines === 0 ? 100 : (coveredLines / totalLines) * 100;
+  if (totalLines === 0) {
+    throw new Error(`No line metrics found in LCOV report at ${lcovPath}`);
+  }
+
+  const pct = (coveredLines / totalLines) * 100;
 
   return { totalLines, coveredLines, pct, lcovPath };
 }


### PR DESCRIPTION
## Summary
- throw an error when the LCOV report lacks LF metrics instead of reporting 100% coverage
- rely on the CLI error handling to surface a clear "No line metrics found" message and non-zero exit

## Testing
- `node - <<'NODE'
const fs = require('fs');
const os = require('os');
const path = require('path');
const { checkCoverage } = require('./scripts/check-coverage');

const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cov-'));
const lcovPath = path.join(tempDir, 'lcov.info');
fs.writeFileSync(lcovPath, 'TN:\nSF:/tmp/example.js\nend_of_record\n');

try {
  checkCoverage({ lcovPath });
  console.error('Expected checkCoverage to throw when no LF metrics are present.');
  process.exit(1);
} catch (error) {
  console.log('Received error:', error.message);
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68cd9528f950833388492429a341c383