### PR TITLE
Integrate ERC20 staking flows and fee recipient handling

### DIFF
--- a/contracts/core/FeePool.sol
+++ b/contracts/core/FeePool.sol
@@ -2,17 +2,22 @@
 pragma solidity 0.8.23;
 
 import {Ownable} from "../libs/Ownable.sol";
+import {IERC20} from "../libs/IERC20.sol";
+import {SafeERC20} from "../libs/SafeERC20.sol";
 
 /// @title FeePool
 /// @notice Records protocol fee accrual for accounting transparency.
 contract FeePool is Ownable {
     event FeeRecorded(uint256 amount);
     event JobRegistryUpdated(address indexed jobRegistry);
+    event FeesBurned(uint256 amount);
 
     address public immutable feeToken;
     address public immutable burnAddress;
     uint256 public totalFeesRecorded;
     address public jobRegistry;
+
+    using SafeERC20 for IERC20;
 
     constructor(address token, address burnAddr) {
         require(token != address(0), "FeePool: token");
@@ -36,5 +41,13 @@ contract FeePool is Ownable {
         require(amount > 0, "FeePool: amount");
         totalFeesRecorded += amount;
         emit FeeRecorded(amount);
+    }
+
+    /// @notice Sends the full token balance to the configured burn address.
+    function burnAccumulatedFees() external onlyOwner {
+        uint256 balance = IERC20(feeToken).balanceOf(address(this));
+        require(balance > 0, "FeePool: nothing to burn");
+        IERC20(feeToken).safeTransfer(burnAddress, balance);
+        emit FeesBurned(balance);
     }
 }

--- a/contracts/libs/IERC20.sol
+++ b/contracts/libs/IERC20.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+/// @dev Minimal ERC20 interface used by the protocol contracts.
+interface IERC20 {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    function transfer(address to, uint256 value) external returns (bool);
+
+    function approve(address spender, uint256 value) external returns (bool);
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}

--- a/contracts/libs/SafeERC20.sol
+++ b/contracts/libs/SafeERC20.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {IERC20} from "./IERC20.sol";
+
+/// @dev Lightweight helpers to safely interact with ERC20 tokens.
+library SafeERC20 {
+    function safeTransfer(IERC20 token, address to, uint256 value) internal {
+        _call(token, abi.encodeWithSelector(token.transfer.selector, to, value));
+    }
+
+    function safeTransferFrom(IERC20 token, address from, address to, uint256 value) internal {
+        _call(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, value));
+    }
+
+    function _call(IERC20 token, bytes memory data) private {
+        (bool success, bytes memory returndata) = address(token).call(data);
+        require(success, "SafeERC20: call failed");
+        if (returndata.length > 0) {
+            require(abi.decode(returndata, (bool)), "SafeERC20: operation failed");
+        }
+    }
+}

--- a/contracts/testing/MockERC20.sol
+++ b/contracts/testing/MockERC20.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {IERC20} from "../libs/IERC20.sol";
+
+/// @dev Simple ERC20 token used for testing flows that require token transfers.
+contract MockERC20 is IERC20 {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals;
+
+    uint256 public override totalSupply;
+
+    mapping(address => uint256) public override balanceOf;
+    mapping(address => mapping(address => uint256)) public override allowance;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        name = name_;
+        symbol = symbol_;
+        decimals = decimals_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(to != address(0), "MockERC20: mint to zero");
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
+        if (msg.sender != from) {
+            uint256 currentAllowance = allowance[from][msg.sender];
+            require(currentAllowance >= amount, "MockERC20: allowance");
+            unchecked {
+                allowance[from][msg.sender] = currentAllowance - amount;
+            }
+            emit Approval(from, msg.sender, allowance[from][msg.sender]);
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(from != address(0) && to != address(0), "MockERC20: transfer zero");
+        uint256 balance = balanceOf[from];
+        require(balance >= amount, "MockERC20: balance");
+        unchecked {
+            balanceOf[from] = balance - amount;
+            balanceOf[to] += amount;
+        }
+        emit Transfer(from, to, amount);
+    }
+
+    function _approve(address owner, address spender, uint256 amount) internal {
+        require(owner != address(0) && spender != address(0), "MockERC20: approve zero");
+        allowance[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+}

--- a/migrations/3_wire_protocol.js
+++ b/migrations/3_wire_protocol.js
@@ -27,6 +27,7 @@ module.exports = async function (_deployer, network, accounts) {
   });
 
   await staking.setJobRegistry(jr.address);
+  await staking.setFeeRecipient(feePool.address);
   await feePool.setJobRegistry(jr.address);
   await dispute.setJobRegistry(jr.address);
   await reputation.setJobRegistry(jr.address);

--- a/test/stakeManager.test.js
+++ b/test/stakeManager.test.js
@@ -1,11 +1,15 @@
-const { expectEvent, expectRevert, constants } = require('@openzeppelin/test-helpers');
+const { expectEvent, expectRevert, constants, BN } = require('@openzeppelin/test-helpers');
 const StakeManager = artifacts.require('StakeManager');
+const MockERC20 = artifacts.require('MockERC20');
 
 contract('StakeManager', (accounts) => {
-  const [owner, registry, staker, other, , , , , , stakeToken] = accounts;
+  const [owner, registry, staker, other, feeRecipient] = accounts;
+  const initialMint = new BN('1000000');
 
   beforeEach(async function () {
-    this.manager = await StakeManager.new(stakeToken, 18, { from: owner });
+    this.token = await MockERC20.new('Stake', 'STK', 18, { from: owner });
+    await this.token.mint(staker, initialMint, { from: owner });
+    this.manager = await StakeManager.new(this.token.address, 18, { from: owner });
   });
 
   it('requires a non-zero staking token', async function () {
@@ -32,8 +36,20 @@ contract('StakeManager', (accounts) => {
 
   it('handles deposits and withdrawals with proper checks', async function () {
     await expectRevert(this.manager.deposit('0', { from: staker }), 'StakeManager: amount');
-    await this.manager.deposit('1000', { from: staker });
+    await expectRevert(this.manager.deposit('1000', { from: staker }), 'StakeManager: allowance');
+
+    await this.token.approve(this.manager.address, '500', { from: staker });
+    await expectRevert(this.manager.deposit('600', { from: staker }), 'StakeManager: allowance');
+
+    await this.token.approve(this.manager.address, '1000', { from: staker });
+    const depositReceipt = await this.manager.deposit('1000', { from: staker });
+    expectEvent(depositReceipt, 'Deposited', { account: staker, amount: new BN('1000') });
     assert.strictEqual((await this.manager.totalDeposits(staker)).toString(), '1000');
+    assert.strictEqual((await this.token.balanceOf(this.manager.address)).toString(), '1000');
+    assert.strictEqual(
+      (await this.token.balanceOf(staker)).toString(),
+      initialMint.sub(new BN('1000')).toString()
+    );
 
     await expectRevert(this.manager.withdraw('0', { from: staker }), 'StakeManager: amount');
     await expectRevert(
@@ -41,13 +57,20 @@ contract('StakeManager', (accounts) => {
       'StakeManager: insufficient'
     );
 
-    await this.manager.withdraw('400', { from: staker });
+    const withdrawReceipt = await this.manager.withdraw('400', { from: staker });
+    expectEvent(withdrawReceipt, 'Withdrawn', { account: staker, amount: new BN('400') });
     assert.strictEqual((await this.manager.totalDeposits(staker)).toString(), '600');
+    assert.strictEqual((await this.token.balanceOf(this.manager.address)).toString(), '600');
+    assert.strictEqual(
+      (await this.token.balanceOf(staker)).toString(),
+      initialMint.sub(new BN('600')).toString()
+    );
   });
 
   describe('with configured registry', () => {
     beforeEach(async function () {
       await this.manager.setJobRegistry(registry, { from: owner });
+      await this.token.approve(this.manager.address, initialMint, { from: staker });
     });
 
     it('enforces registry permissions', async function () {
@@ -93,6 +116,12 @@ contract('StakeManager', (accounts) => {
         'StakeManager: exceeds locked'
       );
 
+      await expectRevert(
+        this.manager.settleStake(staker, '0', '50', { from: registry }),
+        'StakeManager: fee recipient unset'
+      );
+      await this.manager.setFeeRecipient(feeRecipient, { from: owner });
+
       const releaseOnly = await this.manager.settleStake(staker, '100', '0', { from: registry });
       expectEvent(releaseOnly, 'Released', { amount: web3.utils.toBN(100) });
       expectEvent.notEmitted(releaseOnly, 'Slashed');
@@ -104,12 +133,14 @@ contract('StakeManager', (accounts) => {
       expectEvent.notEmitted(slashOnly, 'Released');
       assert.strictEqual((await this.manager.lockedAmounts(staker)).toString(), '550');
       assert.strictEqual((await this.manager.totalDeposits(staker)).toString(), '850');
+      assert.strictEqual((await this.token.balanceOf(feeRecipient)).toString(), '50');
 
       const receipt = await this.manager.settleStake(staker, '250', '150', { from: registry });
       expectEvent(receipt, 'Released', { amount: web3.utils.toBN(250) });
       expectEvent(receipt, 'Slashed', { amount: web3.utils.toBN(150) });
       assert.strictEqual((await this.manager.lockedAmounts(staker)).toString(), '150');
       assert.strictEqual((await this.manager.totalDeposits(staker)).toString(), '700');
+      assert.strictEqual((await this.token.balanceOf(feeRecipient)).toString(), '200');
 
       await expectRevert(
         this.manager.settleStake(staker, '0', '200', { from: registry }),
@@ -124,6 +155,22 @@ contract('StakeManager', (accounts) => {
       const slash = await this.manager.slashStake(staker, '100', { from: registry });
       expectEvent(slash, 'Slashed', { amount: web3.utils.toBN(100) });
       assert.strictEqual((await this.manager.totalDeposits(staker)).toString(), '600');
+      assert.strictEqual((await this.token.balanceOf(feeRecipient)).toString(), '300');
+    });
+
+    it('only allows the owner to configure the fee recipient', async function () {
+      await expectRevert(
+        this.manager.setFeeRecipient(constants.ZERO_ADDRESS, { from: owner }),
+        'StakeManager: fee recipient'
+      );
+      await expectRevert(
+        this.manager.setFeeRecipient(feeRecipient, { from: registry }),
+        'Ownable: caller is not the owner'
+      );
+
+      const receipt = await this.manager.setFeeRecipient(feeRecipient, { from: owner });
+      expectEvent(receipt, 'FeeRecipientUpdated', { feeRecipient });
+      assert.strictEqual(await this.manager.feeRecipient(), feeRecipient);
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace the staking token address in StakeManager with an IERC20 and require allowance-backed deposits, safe withdrawals, and a configurable fee recipient that receives slashed stake
- introduce IERC20 and SafeERC20 helpers together with a MockERC20 test token, route slashed stake to FeePool, and add a burn helper for accumulated fees
- wire the fee recipient during migrations and expand StakeManager, JobRegistry, and FeePool tests to exercise ERC-20 transfers and fee routing

## Testing
- npx hardhat test test/stakeManager.test.js
- npx hardhat test test/jobRegistry.test.js
- npx hardhat test test/feePool.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd97cc9e2083338dee7558642b220a