### PR TITLE
Handle partial slashes when resolving disputes

### DIFF
--- a/contracts/core/JobRegistry.sol
+++ b/contracts/core/JobRegistry.sol
@@ -233,7 +233,10 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         if (slashWorker) {
             uint256 maxSlash = (job.stakeAmount * thresholds.slashBpsMax) / BPS_DENOMINATOR;
             if (slashAmount > maxSlash) revert("JobRegistry: slash bounds");
-            StakeManager(_modules.staking).slashStake(job.worker, slashAmount);
+            if (slashAmount > job.stakeAmount) revert("JobRegistry: slash exceeds stake");
+
+            uint256 releaseAmount = job.stakeAmount - slashAmount;
+            StakeManager(_modules.staking).settleStake(job.worker, releaseAmount, slashAmount);
         } else {
             StakeManager(_modules.staking).releaseStake(job.worker, job.stakeAmount);
         }


### PR DESCRIPTION
## Summary
- call StakeManager.settleStake when applying a partial slash so the remainder is unlocked and ensure the slash amount never exceeds the staked collateral
- extend the dispute resolution test to assert the worker’s locked balance is cleared and only the slashed portion leaves total deposits

## Testing
- npm run test
- npm run coverage

------
https://chatgpt.com/codex/tasks/task_e_68cd9e5c269083338008222177835dad