### PR TITLE
test: add stake manager reentrancy fixtures

### DIFF
--- a/contracts/testing/ReentrantERC20.sol
+++ b/contracts/testing/ReentrantERC20.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+/* solhint-disable one-contract-per-file */
+pragma solidity 0.8.23;
+
+import {MockERC20} from "./MockERC20.sol";
+
+interface IStakeManagerReentrancyReceiver {
+    function onTokenTransfer() external;
+}
+
+/// @dev ERC20 test double that invokes a hook on the recipient when the stake
+/// manager transfers tokens, enabling reentrancy simulations in tests.
+contract ReentrantERC20 is MockERC20 {
+    address public immutable controller;
+    address public reentrantTarget;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_)
+        MockERC20(name_, symbol_, decimals_)
+    {
+        controller = msg.sender;
+    }
+
+    function setReentrantTarget(address target) external {
+        require(msg.sender == controller, "ReentrantERC20: controller");
+        require(target != address(0), "ReentrantERC20: target");
+        reentrantTarget = target;
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal override {
+        if (from == reentrantTarget && to.code.length > 0) {
+            IStakeManagerReentrancyReceiver(to).onTokenTransfer();
+        }
+        super._transfer(from, to, amount);
+    }
+}

--- a/contracts/testing/StakeManagerReentrancyAttacker.sol
+++ b/contracts/testing/StakeManagerReentrancyAttacker.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import {StakeManager} from "../core/StakeManager.sol";
+import {IERC20} from "../libs/IERC20.sol";
+
+/// @dev Helper contract used in tests to attempt reentrant withdrawals from the
+/// stake manager when receiving tokens from a custom ERC20.
+contract StakeManagerReentrancyAttacker {
+    StakeManager public immutable stakeManager;
+    IERC20 public immutable stakeToken;
+
+    uint256 public reenterAmount;
+    bool public reenterCallSucceeded;
+    bool private reentered;
+
+    constructor(address stakeManager_, address stakeToken_) {
+        require(stakeManager_ != address(0), "ReentrancyAttacker: manager");
+        require(stakeToken_ != address(0), "ReentrancyAttacker: token");
+        stakeManager = StakeManager(stakeManager_);
+        stakeToken = IERC20(stakeToken_);
+    }
+
+    function approveAndDeposit(uint256 amount) external {
+        stakeToken.approve(address(stakeManager), amount);
+        stakeManager.deposit(amount);
+    }
+
+    function attemptWithdraw(uint256 withdrawAmount, uint256 reenterAmount_) external {
+        reenterAmount = reenterAmount_;
+        reenterCallSucceeded = false;
+        reentered = false;
+        stakeManager.withdraw(withdrawAmount);
+    }
+
+    function onTokenTransfer() external {
+        require(msg.sender == address(stakeToken), "ReentrancyAttacker: caller");
+        if (!reentered && reenterAmount > 0) {
+            reentered = true;
+            // solhint-disable-next-line avoid-low-level-calls
+            (bool success, ) = address(stakeManager).call(
+                abi.encodeWithSelector(stakeManager.withdraw.selector, reenterAmount)
+            );
+            reenterCallSucceeded = success;
+        }
+    }
+}

--- a/test/stakeManager.test.js
+++ b/test/stakeManager.test.js
@@ -1,6 +1,8 @@
 const { expectEvent, expectRevert, constants, BN } = require('@openzeppelin/test-helpers');
 const StakeManager = artifacts.require('StakeManager');
 const MockERC20 = artifacts.require('MockERC20');
+const ReentrantERC20 = artifacts.require('ReentrantERC20');
+const StakeManagerReentrancyAttacker = artifacts.require('StakeManagerReentrancyAttacker');
 
 contract('StakeManager', (accounts) => {
   const [owner, registry, staker, other, feeRecipient] = accounts;
@@ -171,6 +173,50 @@ contract('StakeManager', (accounts) => {
       const receipt = await this.manager.setFeeRecipient(feeRecipient, { from: owner });
       expectEvent(receipt, 'FeeRecipientUpdated', { feeRecipient });
       assert.strictEqual(await this.manager.feeRecipient(), feeRecipient);
+    });
+  });
+
+  describe('reentrancy protections', () => {
+    beforeEach(async function () {
+      this.reentrantToken = await ReentrantERC20.new('Stake', 'RSTK', 18, { from: owner });
+      this.reentrantManager = await StakeManager.new(this.reentrantToken.address, 18, { from: owner });
+      await this.reentrantToken.setReentrantTarget(this.reentrantManager.address, { from: owner });
+      this.reentrancyAttacker = await StakeManagerReentrancyAttacker.new(
+        this.reentrantManager.address,
+        this.reentrantToken.address,
+        { from: owner }
+      );
+
+      await this.reentrantManager.setJobRegistry(registry, { from: owner });
+      await this.reentrantToken.mint(this.reentrancyAttacker.address, '1000', { from: owner });
+      await this.reentrancyAttacker.approveAndDeposit('1000', { from: owner });
+      await this.reentrantManager.lockStake(this.reentrancyAttacker.address, '800', { from: registry });
+    });
+
+    it('prevents reentrant withdrawals from breaking stake accounting', async function () {
+      const receipt = await this.reentrancyAttacker.attemptWithdraw('200', '1', { from: owner });
+      await expectEvent.inTransaction(receipt.tx, this.reentrantManager, 'Withdrawn', {
+        account: this.reentrancyAttacker.address,
+        amount: new BN('200'),
+      });
+
+      assert.strictEqual(
+        (await this.reentrantManager.totalDeposits(this.reentrancyAttacker.address)).toString(),
+        '800'
+      );
+      assert.strictEqual(
+        (await this.reentrantManager.lockedAmounts(this.reentrancyAttacker.address)).toString(),
+        '800'
+      );
+      assert.strictEqual(
+        (await this.reentrantManager.availableStake(this.reentrancyAttacker.address)).toString(),
+        '0'
+      );
+      assert.strictEqual(
+        (await this.reentrantToken.balanceOf(this.reentrancyAttacker.address)).toString(),
+        '200'
+      );
+      assert.isFalse(await this.reentrancyAttacker.reenterCallSucceeded());
     });
   });
 });


### PR DESCRIPTION
## Summary
- add dedicated helper contracts for simulating reentrant ERC20 behaviour in tests
- extend StakeManager tests with a reentrancy scenario that asserts withdraw emits the expected event from the configured manager

## Testing
- Attempted `npm test` *(Hardhat node spammed verbose RPC output and the run became impractical in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdae2f946c8333846f098b01abaa86