### PR TITLE
Lock job registry configuration to prevent post-deploy swaps

### DIFF
--- a/contracts/core/DisputeModule.sol
+++ b/contracts/core/DisputeModule.sol
@@ -14,6 +14,7 @@ contract DisputeModule is Ownable {
 
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "DisputeModule: registry");
+        require(jobRegistry == address(0), "DisputeModule: registry already set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/FeePool.sol
+++ b/contracts/core/FeePool.sol
@@ -28,6 +28,7 @@ contract FeePool is Ownable {
 
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "FeePool: registry");
+        require(jobRegistry == address(0), "FeePool: registry already set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/ReputationEngine.sol
+++ b/contracts/core/ReputationEngine.sol
@@ -14,6 +14,7 @@ contract ReputationEngine is Ownable {
 
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "ReputationEngine: registry");
+        require(jobRegistry == address(0), "ReputationEngine: registry already set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/StakeManager.sol
+++ b/contracts/core/StakeManager.sol
@@ -43,6 +43,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @param registry Address of the registry contract that can manage stake locks.
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "StakeManager: zero registry");
+        require(jobRegistry == address(0), "StakeManager: registry already set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/test/disputeModule.test.js
+++ b/test/disputeModule.test.js
@@ -22,6 +22,11 @@ contract('DisputeModule', (accounts) => {
     const receipt = await this.module.setJobRegistry(registry, { from: owner });
     expectEvent(receipt, 'JobRegistryUpdated', { jobRegistry: registry });
     assert.strictEqual(await this.module.jobRegistry(), registry);
+
+    await expectRevert(
+      this.module.setJobRegistry(raiser, { from: owner }),
+      'DisputeModule: registry already set'
+    );
   });
 
   it('emits events only when called by the registry', async function () {

--- a/test/feePool.test.js
+++ b/test/feePool.test.js
@@ -18,6 +18,11 @@ contract('FeePool', (accounts) => {
     const receipt = await this.pool.setJobRegistry(registry, { from: owner });
     expectEvent(receipt, 'JobRegistryUpdated', { jobRegistry: registry });
     assert.strictEqual(await this.pool.jobRegistry(), registry);
+
+    await expectRevert(
+      this.pool.setJobRegistry(stranger, { from: owner }),
+      'FeePool: registry already set'
+    );
   });
 
   it('requires non-zero constructor arguments', async function () {

--- a/test/reputationEngine.test.js
+++ b/test/reputationEngine.test.js
@@ -22,6 +22,11 @@ contract('ReputationEngine', (accounts) => {
     const receipt = await this.engine.setJobRegistry(registry, { from: owner });
     expectEvent(receipt, 'JobRegistryUpdated', { jobRegistry: registry });
     assert.strictEqual(await this.engine.jobRegistry(), registry);
+
+    await expectRevert(
+      this.engine.setJobRegistry(worker, { from: owner }),
+      'ReputationEngine: registry already set'
+    );
   });
 
   it('adjusts reputation only when called by registry', async function () {

--- a/test/stakeManager.test.js
+++ b/test/stakeManager.test.js
@@ -32,6 +32,11 @@ contract('StakeManager', (accounts) => {
     const receipt = await this.manager.setJobRegistry(registry, { from: owner });
     expectEvent(receipt, 'JobRegistryUpdated', { jobRegistry: registry });
     assert.strictEqual(await this.manager.jobRegistry(), registry);
+
+    await expectRevert(
+      this.manager.setJobRegistry(other, { from: owner }),
+      'StakeManager: registry already set'
+    );
   });
 
   it('handles deposits and withdrawals with proper checks', async function () {


### PR DESCRIPTION
## Summary
- prevent DisputeModule, FeePool, ReputationEngine, and StakeManager job registry pointers from being reconfigured after the initial wiring
- extend module unit tests to assert that subsequent setJobRegistry calls revert with the new access-control guards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdba032758833395e6ac722b0c7f15