### PR TITLE
docs: add natSpec coverage and lint fixes

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -14,6 +14,8 @@ contract Migrations {
         _;
     }
 
+    /// @notice Updates the highest completed migration index.
+    /// @param completed The latest migration sequence number that finished execution.
     function setCompleted(uint256 completed) external restricted {
         lastCompletedMigration = completed;
     }

--- a/contracts/core/DisputeModule.sol
+++ b/contracts/core/DisputeModule.sol
@@ -16,7 +16,7 @@ contract DisputeModule is Ownable {
     /// @param registry Address of the job registry contract.
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "DisputeModule: registry");
-        require(jobRegistry == address(0), "DisputeModule: registry already set");
+        require(jobRegistry == address(0), "DisputeModule: registry set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/ReputationEngine.sol
+++ b/contracts/core/ReputationEngine.sol
@@ -16,7 +16,7 @@ contract ReputationEngine is Ownable {
     /// @param registry Address of the job registry contract.
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "ReputationEngine: registry");
-        require(jobRegistry == address(0), "ReputationEngine: registry already set");
+        require(jobRegistry == address(0), "ReputationEngine: registry set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/StakeManager.sol
+++ b/contracts/core/StakeManager.sol
@@ -46,7 +46,7 @@ contract StakeManager is Ownable, ReentrancyGuard {
     /// @param registry Address of the registry contract that can manage stake locks.
     function setJobRegistry(address registry) external onlyOwner {
         require(registry != address(0), "StakeManager: zero registry");
-        require(jobRegistry == address(0), "StakeManager: registry already set");
+        require(jobRegistry == address(0), "StakeManager: registry set");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/testing/ClientActor.sol
+++ b/contracts/core/testing/ClientActor.sol
@@ -8,14 +8,21 @@ import {JobRegistry} from "../JobRegistry.sol";
 contract ClientActor {
     JobRegistry private immutable jobRegistry;
 
+    /// @notice Initializes the client helper with the protocol job registry.
+    /// @param jobRegistry_ Job registry used to create jobs and raise disputes.
     constructor(JobRegistry jobRegistry_) {
         jobRegistry = jobRegistry_;
     }
 
+    /// @notice Creates a new job using the backing job registry instance.
+    /// @param stakeAmount Amount of stake required from the worker.
+    /// @return jobId Identifier assigned to the newly created job.
     function createJob(uint256 stakeAmount) external returns (uint256) {
         return jobRegistry.createJob(stakeAmount);
     }
 
+    /// @notice Raises a dispute for the provided job identifier via the job registry.
+    /// @param jobId Identifier of the job being disputed.
     function raiseDispute(uint256 jobId) external {
         jobRegistry.raiseDispute(jobId);
     }

--- a/contracts/core/testing/WorkerActor.sol
+++ b/contracts/core/testing/WorkerActor.sol
@@ -10,23 +10,36 @@ contract WorkerActor {
     StakeManager private immutable stakeManager;
     JobRegistry private immutable jobRegistry;
 
+    /// @notice Initializes the worker helper with references to core protocol contracts.
+    /// @param stakeManager_ Stake manager contract controlling worker balances.
+    /// @param jobRegistry_ Job registry coordinating job commitments.
     constructor(StakeManager stakeManager_, JobRegistry jobRegistry_) {
         stakeManager = stakeManager_;
         jobRegistry = jobRegistry_;
     }
 
+    /// @notice Deposits tokens into the stake manager using the worker actor.
+    /// @param amount Quantity of tokens to deposit.
     function deposit(uint256 amount) external {
         stakeManager.deposit(amount);
     }
 
+    /// @notice Withdraws unlocked stake from the stake manager on behalf of the worker.
+    /// @param amount Quantity of tokens to withdraw.
     function withdraw(uint256 amount) external {
         stakeManager.withdraw(amount);
     }
 
+    /// @notice Commits to a job via the job registry with the provided hash.
+    /// @param jobId Identifier of the job being committed to.
+    /// @param commitHash Hash of the secret generated for the job commit.
     function commit(uint256 jobId, bytes32 commitHash) external {
         jobRegistry.commitJob(jobId, commitHash);
     }
 
+    /// @notice Reveals the commitment secret for a job in the job registry.
+    /// @param jobId Identifier of the job being revealed.
+    /// @param commitSecret Secret value matching the commitment hash.
     function reveal(uint256 jobId, bytes32 commitSecret) external {
         jobRegistry.revealJob(jobId, commitSecret);
     }

--- a/contracts/libs/SafeERC20.sol
+++ b/contracts/libs/SafeERC20.sol
@@ -14,7 +14,7 @@ library SafeERC20 {
     }
 
     function _call(IERC20 token, bytes memory data) private {
-        // solhint-disable-next-line avoid-low-level-calls
+        /* solhint-disable-next-line avoid-low-level-calls */
         // slither-disable-next-line low-level-calls
         (bool success, bytes memory returndata) = address(token).call(data);
         require(success, "SafeERC20: call failed");

--- a/contracts/testing/MockERC20.sol
+++ b/contracts/testing/MockERC20.sol
@@ -14,12 +14,19 @@ contract MockERC20 is IERC20 {
     mapping(address => uint256) public override balanceOf;
     mapping(address => mapping(address => uint256)) public override allowance;
 
+    /// @notice Initializes the mock token with metadata values used in tests.
+    /// @param name_ Token name exposed via the ERC20 interface.
+    /// @param symbol_ Token symbol exposed via the ERC20 interface.
+    /// @param decimals_ Number of decimals the token uses.
     constructor(string memory name_, string memory symbol_, uint8 decimals_) {
         name = name_;
         symbol = symbol_;
         decimals = decimals_;
     }
 
+    /// @notice Mints tokens to the desired recipient for testing scenarios.
+    /// @param to Address that will receive the new tokens.
+    /// @param amount Quantity of tokens to mint.
     function mint(address to, uint256 amount) external {
         require(to != address(0), "MockERC20: mint to zero");
         totalSupply += amount;
@@ -27,16 +34,29 @@ contract MockERC20 is IERC20 {
         emit Transfer(address(0), to, amount);
     }
 
+    /// @notice Transfers tokens from the caller to a destination address.
+    /// @param to Recipient of the transferred tokens.
+    /// @param amount Quantity of tokens to send.
+    /// @return True when the transfer succeeds.
     function transfer(address to, uint256 amount) external override returns (bool) {
         _transfer(msg.sender, to, amount);
         return true;
     }
 
+    /// @notice Approves a spender to transfer tokens from the caller.
+    /// @param spender Address allowed to transfer tokens on behalf of the caller.
+    /// @param amount Maximum amount the spender can transfer.
+    /// @return True when the approval succeeds.
     function approve(address spender, uint256 amount) external override returns (bool) {
         _approve(msg.sender, spender, amount);
         return true;
     }
 
+    /// @notice Transfers tokens from a source address to a destination using allowance.
+    /// @param from Account that currently holds the tokens.
+    /// @param to Recipient of the transferred tokens.
+    /// @param amount Quantity of tokens to send.
+    /// @return True when the transfer succeeds.
     function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
         if (msg.sender != from) {
             uint256 currentAllowance = allowance[from][msg.sender];


### PR DESCRIPTION
## Summary
- add NatSpec coverage to testing utilities and fuzz harness contracts
- document the migrations helper and clean up revert reasons flagged by solhint
- adjust SafeERC20 annotations so linting and static analysis remain noise-free

## Testing
- `slither .`
- `npm run lint:sol`


------
https://chatgpt.com/codex/tasks/task_e_68cdbed8c4d88333a89fe7cdfbd1ab2a