### PR TITLE
Use mock token for Echidna staking

### DIFF
--- a/contracts/core/testing/WorkerActor.sol
+++ b/contracts/core/testing/WorkerActor.sol
@@ -5,23 +5,33 @@ pragma solidity 0.8.23;
 
 import {StakeManager} from "../StakeManager.sol";
 import {JobRegistry} from "../JobRegistry.sol";
+import {IERC20} from "../../libs/IERC20.sol";
 
 contract WorkerActor {
     StakeManager private immutable stakeManager;
     JobRegistry private immutable jobRegistry;
+    IERC20 private immutable stakeToken;
 
     /// @notice Initializes the worker helper with references to core protocol contracts.
     /// @param stakeManager_ Stake manager contract controlling worker balances.
     /// @param jobRegistry_ Job registry coordinating job commitments.
-    constructor(StakeManager stakeManager_, JobRegistry jobRegistry_) {
+    constructor(StakeManager stakeManager_, JobRegistry jobRegistry_, IERC20 stakeToken_) {
         stakeManager = stakeManager_;
         jobRegistry = jobRegistry_;
+        stakeToken = stakeToken_;
     }
 
     /// @notice Deposits tokens into the stake manager using the worker actor.
     /// @param amount Quantity of tokens to deposit.
     function deposit(uint256 amount) external {
+        _approveIfNeeded(amount);
         stakeManager.deposit(amount);
+    }
+
+    /// @notice Ensures the stake manager has enough allowance to transfer tokens.
+    /// @param amount Minimum allowance to guarantee for the stake manager.
+    function approveStakeManager(uint256 amount) external {
+        _approveIfNeeded(amount);
     }
 
     /// @notice Withdraws unlocked stake from the stake manager on behalf of the worker.
@@ -42,5 +52,11 @@ contract WorkerActor {
     /// @param commitSecret Secret value matching the commitment hash.
     function reveal(uint256 jobId, bytes32 commitSecret) external {
         jobRegistry.revealJob(jobId, commitSecret);
+    }
+
+    function _approveIfNeeded(uint256 amount) private {
+        if (stakeToken.allowance(address(this), address(stakeManager)) < amount) {
+            stakeToken.approve(address(stakeManager), type(uint256).max);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- deploy a dedicated MockERC20 for the Echidna harness and wire it into the stake and fee modules
- mint large token balances to both worker actors so fuzzed staking flows can execute
- update the worker actor helper to track the stake token, manage allowances, and expose an approval helper

## Testing
- `echidna-test contracts/core/EchidnaJobRegistryInvariants.sol --config tools/echidna.yaml` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc9556ac883338a6158a7aadfc347