### PR TITLE
Update Echidna workflow to use solc 0.8.23

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -49,8 +49,8 @@ jobs:
           python3 -m pip install --user crytic-compile
           echo "$user_base/bin" >> "$GITHUB_PATH"
           export PATH="$user_base/bin:$PATH"
-          solc-select install 0.8.20
-          solc-select use 0.8.20
+          solc-select install 0.8.23
+          solc-select use 0.8.23
       - name: Run Echidna smoke
         run: |
           set -euxo pipefail


### PR DESCRIPTION
## Summary
- align the Echidna GitHub Actions workflow with the contracts' pragma by switching solc-select to version 0.8.23

## Testing
- echidna-test ./contracts/core/EchidnaJobRegistryInvariants.sol --contract EchidnaJobRegistryInvariants --config tools/echidna.yaml

------
https://chatgpt.com/codex/tasks/task_e_68cdfd4b3ffc8333b07758de4751dfab