### PR TITLE
Fix npm ci failure from bundled fsevents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14496,6 +14496,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "extraneous": true,
+      "optional": true,
       "os": [
         "darwin"
       ],


### PR DESCRIPTION
## Summary
- mark the bundled Ganache fsevents dependency as optional so npm ci no longer fails on Linux runners

## Testing
- npm ci

------
https://chatgpt.com/codex/tasks/task_e_68ce01e7f0088333b968c46b9e527567