### PR TITLE
Improve local Hardhat lifecycle management

### DIFF
--- a/scripts/export-artifacts-runner.js
+++ b/scripts/export-artifacts-runner.js
@@ -1,72 +1,205 @@
 const { spawn } = require('child_process');
+const http = require('http');
+const net = require('net');
 
-function wait(ms) {
+const HARDHAT_CLI = require.resolve('hardhat/internal/cli/cli');
+
+const HOST = process.env.HARDHAT_HOST || '127.0.0.1';
+const PORT = Number(process.env.HARDHAT_PORT || 8545);
+const HARDHAT_READY_TIMEOUT = 60_000;
+
+function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function jsonRpcRequest({ host, port, body, timeout }) {
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        host,
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+        timeout,
+      },
+      (response) => {
+        const chunks = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => {
+          if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+            resolve(Buffer.concat(chunks).toString('utf8'));
+          } else {
+            reject(new Error(`Unexpected status code ${response.statusCode}`));
+          }
+        });
+      }
+    );
+
+    request.on('error', reject);
+    request.on('timeout', () => {
+      request.destroy(new Error('Request timed out'));
+    });
+
+    request.write(body);
+    request.end();
+  });
+}
+
+async function ensurePortAvailable({ host = HOST, port = PORT } = {}) {
+  await new Promise((resolve, reject) => {
+    const tester = net.createServer();
+    tester.once('error', (error) => {
+      tester.close(() => {
+        if (error.code === 'EADDRINUSE') {
+          reject(new Error(`Port ${port} on ${host} is already in use. Stop the process listening on it or set HARDHAT_PORT.`));
+        } else {
+          reject(error);
+        }
+      });
+    });
+    tester.once('listening', () => {
+      tester.close(resolve);
+    });
+    tester.listen(port, host);
+  });
+}
+
+async function waitForHardhatNode({ host = HOST, port = PORT, timeout = HARDHAT_READY_TIMEOUT, interval = 500 } = {}) {
+  const payload = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'net_version', params: [] });
+  const start = Date.now();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await jsonRpcRequest({ host, port, body: payload, timeout: interval });
+      return;
+    } catch (error) {
+      if (Date.now() - start >= timeout) {
+        throw new Error(`Timed out waiting for Hardhat node on ${host}:${port}: ${error.message}`);
+      }
+      await delay(interval);
+    }
+  }
 }
 
 function runCommand(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: 'inherit', ...options });
-    child.on('exit', (code) => {
+
+    child.once('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`${command} ${args.join(' ')} terminated with signal ${signal}`));
+        return;
+      }
       if (code === 0) {
         resolve();
       } else {
         reject(new Error(`${command} ${args.join(' ')} exited with code ${code}`));
       }
     });
-    child.on('error', (error) => reject(error));
+
+    child.once('error', (error) => {
+      reject(new Error(`Failed to start ${command} ${args.join(' ')}: ${error.message}`));
+    });
   });
 }
 
-async function stopProcess(proc) {
-  if (!proc || proc.killed) {
+async function stopProcess(proc, { signal = 'SIGINT', forceSignal = 'SIGKILL', timeout = 5000 } = {}) {
+  if (!proc || proc.killed || proc.exitCode !== null) {
     return;
   }
 
   await new Promise((resolve) => {
     let settled = false;
-    const onExit = () => {
+
+    const cleanup = () => {
       if (!settled) {
         settled = true;
         resolve();
       }
     };
 
-    const timeout = setTimeout(() => {
+    const timer = setTimeout(() => {
       if (!settled) {
-        settled = true;
         try {
-          process.kill(-proc.pid, 'SIGKILL');
+          proc.kill(forceSignal);
         } catch (_) {
-          proc.kill('SIGKILL');
+          // ignore
         }
-        resolve();
       }
-    }, 5000);
+    }, timeout);
 
     proc.once('exit', () => {
-      clearTimeout(timeout);
-      onExit();
+      clearTimeout(timer);
+      cleanup();
     });
 
     try {
-      process.kill(-proc.pid, 'SIGINT');
-    } catch (_) {
-      proc.kill('SIGINT');
+      proc.kill(signal);
+    } catch (error) {
+      if (error.code === 'ESRCH') {
+        clearTimeout(timer);
+        cleanup();
+        return;
+      }
+      try {
+        proc.kill(forceSignal);
+      } catch (_) {
+        // ignore
+      }
     }
   });
 }
 
+async function startHardhatNode() {
+  await ensurePortAvailable();
+
+  const hardhat = spawn(process.execPath, [HARDHAT_CLI, 'node', '--hostname', HOST, '--port', String(PORT)], {
+    stdio: 'inherit',
+  });
+
+  await new Promise((resolve, reject) => {
+    const handleExit = (code, signal) => {
+      reject(
+        new Error(
+          `Hardhat node exited before it became ready (code: ${code ?? 'null'}${signal ? `, signal: ${signal}` : ''})`
+        )
+      );
+    };
+
+    const handleError = (error) => {
+      reject(new Error(`Failed to start Hardhat node: ${error.message}`));
+    };
+
+    hardhat.once('exit', handleExit);
+    hardhat.once('error', handleError);
+
+    waitForHardhatNode()
+      .then(() => {
+        hardhat.off('exit', handleExit);
+        hardhat.off('error', handleError);
+        resolve();
+      })
+      .catch((error) => {
+        hardhat.off('exit', handleExit);
+        hardhat.off('error', handleError);
+        reject(error);
+      });
+  });
+
+  return hardhat;
+}
+
 async function run() {
   const network = process.env.NETWORK || 'development';
-  const hardhat = spawn(
-    'npx',
-    ['hardhat', 'node', '--hostname', '127.0.0.1', '--port', '8545'],
-    { stdio: 'inherit', detached: true }
-  );
+  let hardhat;
 
   try {
-    await wait(5000);
+    hardhat = await startHardhatNode();
 
     await runCommand('npx', ['truffle', 'migrate', '--reset', '--network', network], {
       env: { ...process.env, TRUFFLE_TEST: 'true' },
@@ -76,11 +209,9 @@ async function run() {
       env: { ...process.env, NETWORK: network },
     });
 
-    await runCommand('node', ['scripts/export-abis.js'], {
-      env: process.env,
-    });
+    await runCommand('node', ['scripts/export-abis.js'], { env: process.env });
   } catch (error) {
-    console.error(error);
+    console.error(error.message || error);
     process.exitCode = 1;
   } finally {
     await stopProcess(hardhat);
@@ -88,6 +219,6 @@ async function run() {
 }
 
 run().catch((error) => {
-  console.error(error);
+  console.error(error.message || error);
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- guard the artifact export runner against occupied ports and wait for the JSON-RPC endpoint before migrations
- spawn the Hardhat CLI directly so the runner can terminate the node cleanly after exporting artifacts
- mirror the lifecycle fixes in the hardhat:test helper to avoid orphaned nodes and handle signals reliably

## Testing
- npm run lint:sol
- npm test
- npm run coverage
- npm run export:artifacts

------
https://chatgpt.com/codex/tasks/task_e_68ce0ae6e1248333a4693355ce647553