### PR TITLE
Silence solhint warning for SafeERC20 helper

### DIFF
--- a/contracts/libs/SafeERC20.sol
+++ b/contracts/libs/SafeERC20.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
+// solhint-disable avoid-low-level-calls
+
 import {IERC20} from "./IERC20.sol";
 
 /// @dev Lightweight helpers to safely interact with ERC20 tokens.
@@ -14,7 +16,7 @@ library SafeERC20 {
     }
 
     function _call(IERC20 token, bytes memory data) private {
-        /* solhint-disable-next-line avoid-low-level-calls */
+        // solhint-disable-next-line avoid-low-level-calls
         // slither-disable-next-line low-level-calls
         (bool success, bytes memory returndata) = address(token).call(data);
         require(success, "SafeERC20: call failed");


### PR DESCRIPTION
## Summary
- disable solhint's avoid-low-level-calls rule for the SafeERC20 helper
- convert the inline suppression comment to line comment so the rule remains scoped to the low-level call

## Testing
- npm run lint:sol
- npm run test
- npm run coverage

------
https://chatgpt.com/codex/tasks/task_e_68ce0e1b6ea88333afdb901118b15a2a