### PR TITLE
test: expand protocol coverage and scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14496,7 +14496,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "extraneous": true,
-      "optional": true,
       "os": [
         "darwin"
       ],


### PR DESCRIPTION
## Summary
- extend the job registry test harness with custom error metadata and reusable state constants
- harden dispute lifecycle coverage by asserting expected custom errors and adding an owner-only resolution regression test
- add an actor-driven integration scenario that exercises dispute escalation without slashing using the WorkerActor and ClientActor helpers

## Testing
- npm test
- npm run coverage
- echidna-test contracts/core/EchidnaJobRegistryInvariants.sol --config tools/echidna.yaml *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce14cdbb0883338fffd915520acc38