### PR TITLE
Fix npm ci on non-mac platforms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14496,6 +14496,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "extraneous": true,
+      "optional": true,
       "os": [
         "darwin"
       ],


### PR DESCRIPTION
## Summary
- mark the ganache vendored fsevents dependency as optional so npm ci skips it on non-mac hosts

## Testing
- npm ci
- npm run build
- npm run lint:sol
- npm run test
- npm run coverage
- npm run export:artifacts

------
https://chatgpt.com/codex/tasks/task_e_68ce1925f2d48333bdef1bb5d944eed9