### PR TITLE
Add reusable ERC20 and ENS mocks

### DIFF
--- a/contracts/core/EchidnaJobRegistryInvariants.sol
+++ b/contracts/core/EchidnaJobRegistryInvariants.sol
@@ -12,7 +12,7 @@ import {IdentityRegistry} from "./IdentityRegistry.sol";
 import {JobRegistry} from "./JobRegistry.sol";
 import {WorkerActor} from "./testing/WorkerActor.sol";
 import {ClientActor} from "./testing/ClientActor.sol";
-import {MockERC20} from "../testing/MockERC20.sol";
+import {MockERC20} from "../libs/MockERC20.sol";
 import {ReentrancyGuard} from "../libs/ReentrancyGuard.sol";
 
 /* solhint-disable func-name-mixedcase */
@@ -42,7 +42,13 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
     uint256 private expectedFees;
 
     constructor() {
-        stakeToken = new MockERC20("Stake Token", "STK", 18);
+        stakeToken = new MockERC20(
+            "Stake Token",
+            "STK",
+            18,
+            address(this),
+            WORKER_INITIAL_BALANCE * workers.length
+        );
         stakeManager = new StakeManager(address(stakeToken), stakeToken.decimals());
         feePool = new FeePool(address(stakeToken), address(0xDEAD));
         validationModule = new ValidationModule();
@@ -73,7 +79,7 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
         for (uint256 i = 0; i < workers.length; ++i) {
             WorkerActor worker = new WorkerActor(stakeManager, jobRegistry, stakeToken);
             workers[i] = worker;
-            stakeToken.mint(address(worker), WORKER_INITIAL_BALANCE);
+            stakeToken.transfer(address(worker), WORKER_INITIAL_BALANCE);
             worker.approveStakeManager(type(uint256).max);
         }
 

--- a/contracts/core/testing/WorkerActor.sol
+++ b/contracts/core/testing/WorkerActor.sol
@@ -56,7 +56,8 @@ contract WorkerActor {
 
     function _approveIfNeeded(uint256 amount) private {
         if (stakeToken.allowance(address(this), address(stakeManager)) < amount) {
-            stakeToken.approve(address(stakeManager), type(uint256).max);
+            bool success = stakeToken.approve(address(stakeManager), type(uint256).max);
+            require(success, "WorkerActor: approve failed");
         }
     }
 }

--- a/contracts/libs/MockENSRegistry.sol
+++ b/contracts/libs/MockENSRegistry.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+/// @dev Lightweight ENS registry used for tests that require ownership tracking.
+contract MockENSRegistry {
+    event Transfer(bytes32 indexed node, address owner);
+    event NewOwner(bytes32 indexed node, bytes32 indexed label, address owner);
+
+    mapping(bytes32 => address) private _owners;
+
+    constructor() {
+        _owners[bytes32(0)] = msg.sender;
+        emit Transfer(bytes32(0), msg.sender);
+    }
+
+    /// @notice Returns the current owner for a node hash.
+    /// @param node Hash identifying the ENS node.
+    /// @return Address that controls the specified node.
+    function owner(bytes32 node) external view returns (address) {
+        return _owners[node];
+    }
+
+    /// @notice Assigns ownership of a node to a new address.
+    /// @param node Hash identifying the ENS node being updated.
+    /// @param newOwner Address that will become the new owner of the node.
+    function setOwner(bytes32 node, address newOwner) external {
+        require(_owners[node] == msg.sender, "MockENSRegistry: owner");
+        _setOwner(node, newOwner);
+    }
+
+    /// @notice Assigns ownership of a subnode derived from the provided label.
+    /// @param node Parent node hash.
+    /// @param label Label used to derive the subnode hash.
+    /// @param newOwner Address that will own the derived subnode.
+    /// @return subnode Hash of the derived subnode.
+    function setSubnodeOwner(bytes32 node, bytes32 label, address newOwner) external returns (bytes32 subnode) {
+        require(_owners[node] == msg.sender, "MockENSRegistry: owner");
+        subnode = keccak256(abi.encodePacked(node, label));
+        _setOwner(subnode, newOwner);
+        emit NewOwner(node, label, newOwner);
+    }
+
+    function _setOwner(bytes32 node, address newOwner) internal {
+        _owners[node] = newOwner;
+        emit Transfer(node, newOwner);
+    }
+}

--- a/contracts/libs/MockERC20.sol
+++ b/contracts/libs/MockERC20.sol
@@ -52,26 +52,44 @@ contract MockERC20 is IERC20 {
         return true;
     }
 
+    /// @notice Increases the allowance granted to the spender.
+    /// @param spender Address allowed to transfer tokens on behalf of the caller.
+    /// @param addedValue Additional tokens the spender can transfer.
+    /// @return True when the update succeeds.
+    function increaseAllowance(address spender, uint256 addedValue) external returns (bool) {
+        uint256 newAllowance = allowance[msg.sender][spender] + addedValue;
+        _approve(msg.sender, spender, newAllowance);
+        return true;
+    }
+
+    /// @notice Decreases the allowance granted to the spender.
+    /// @param spender Address allowed to transfer tokens on behalf of the caller.
+    /// @param subtractedValue Amount to subtract from the current allowance.
+    /// @return True when the update succeeds.
+    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool) {
+        uint256 currentAllowance = allowance[msg.sender][spender];
+        require(currentAllowance >= subtractedValue, "MockERC20: allowance");
+        uint256 newAllowance;
+        unchecked {
+            newAllowance = currentAllowance - subtractedValue;
+        }
+        _approve(msg.sender, spender, newAllowance);
+        return true;
+    }
+
     /// @notice Transfers tokens from a source address to a destination using allowance.
     /// @param from Account that currently holds the tokens.
     /// @param to Recipient of the transferred tokens.
     /// @param amount Quantity of tokens to send.
     /// @return True when the transfer succeeds.
     function transferFrom(address from, address to, uint256 amount) external override returns (bool) {
-        if (msg.sender != from) {
-            uint256 currentAllowance = allowance[from][msg.sender];
-            require(currentAllowance >= amount, "MockERC20: allowance");
-            unchecked {
-                allowance[from][msg.sender] = currentAllowance - amount;
-            }
-            emit Approval(from, msg.sender, allowance[from][msg.sender]);
-        }
+        _spendAllowance(from, msg.sender, amount);
         _transfer(from, to, amount);
         return true;
     }
 
     function _transfer(address from, address to, uint256 amount) internal {
-        require(from != address(0) && to != address(0), "MockERC20: transfer");
+        require(from != address(0) && to != address(0), "MockERC20: transfer zero");
         uint256 balance = balanceOf[from];
         require(balance >= amount, "MockERC20: balance");
         unchecked {
@@ -82,12 +100,30 @@ contract MockERC20 is IERC20 {
     }
 
     function _approve(address owner, address spender, uint256 amount) internal {
-        require(owner != address(0) && spender != address(0), "MockERC20: approve");
+        require(owner != address(0) && spender != address(0), "MockERC20: approve zero");
         allowance[owner][spender] = amount;
         emit Approval(owner, spender, amount);
     }
 
+    function _spendAllowance(address owner, address spender, uint256 amount) internal {
+        if (spender == owner) {
+            return;
+        }
+
+        uint256 currentAllowance = allowance[owner][spender];
+        if (currentAllowance == type(uint256).max) {
+            return;
+        }
+
+        require(currentAllowance >= amount, "MockERC20: allowance");
+        unchecked {
+            allowance[owner][spender] = currentAllowance - amount;
+        }
+        emit Approval(owner, spender, allowance[owner][spender]);
+    }
+
     function _mint(address to, uint256 amount) internal {
+        require(to != address(0), "MockERC20: mint to zero");
         totalSupply += amount;
         balanceOf[to] += amount;
         emit Transfer(address(0), to, amount);

--- a/contracts/libs/MockERC20.sol
+++ b/contracts/libs/MockERC20.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import {IERC20} from "../libs/IERC20.sol";
+import {IERC20} from "./IERC20.sol";
 
-/// @dev Simple ERC20 token used for testing flows that require token transfers.
+/// @dev Minimal ERC20 token used in tests and local deployments.
 contract MockERC20 is IERC20 {
     string public name;
     string public symbol;
@@ -14,24 +14,24 @@ contract MockERC20 is IERC20 {
     mapping(address => uint256) public override balanceOf;
     mapping(address => mapping(address => uint256)) public override allowance;
 
-    /// @notice Initializes the mock token with metadata values used in tests.
+    /// @notice Initializes the mock token and mints the initial supply.
     /// @param name_ Token name exposed via the ERC20 interface.
     /// @param symbol_ Token symbol exposed via the ERC20 interface.
     /// @param decimals_ Number of decimals the token uses.
-    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+    /// @param initialHolder Account receiving the initial token allocation.
+    /// @param initialSupply Quantity of tokens to mint during deployment.
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals_,
+        address initialHolder,
+        uint256 initialSupply
+    ) {
+        require(initialHolder != address(0), "MockERC20: holder");
         name = name_;
         symbol = symbol_;
         decimals = decimals_;
-    }
-
-    /// @notice Mints tokens to the desired recipient for testing scenarios.
-    /// @param to Address that will receive the new tokens.
-    /// @param amount Quantity of tokens to mint.
-    function mint(address to, uint256 amount) external {
-        require(to != address(0), "MockERC20: mint to zero");
-        totalSupply += amount;
-        balanceOf[to] += amount;
-        emit Transfer(address(0), to, amount);
+        _mint(initialHolder, initialSupply);
     }
 
     /// @notice Transfers tokens from the caller to a destination address.
@@ -71,7 +71,7 @@ contract MockERC20 is IERC20 {
     }
 
     function _transfer(address from, address to, uint256 amount) internal {
-        require(from != address(0) && to != address(0), "MockERC20: transfer zero");
+        require(from != address(0) && to != address(0), "MockERC20: transfer");
         uint256 balance = balanceOf[from];
         require(balance >= amount, "MockERC20: balance");
         unchecked {
@@ -82,8 +82,14 @@ contract MockERC20 is IERC20 {
     }
 
     function _approve(address owner, address spender, uint256 amount) internal {
-        require(owner != address(0) && spender != address(0), "MockERC20: approve zero");
+        require(owner != address(0) && spender != address(0), "MockERC20: approve");
         allowance[owner][spender] = amount;
         emit Approval(owner, spender, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
     }
 }

--- a/test/feePool.test.js
+++ b/test/feePool.test.js
@@ -6,8 +6,7 @@ contract('FeePool', (accounts) => {
   const [owner, registry, stranger, burnAddress] = accounts;
 
   beforeEach(async function () {
-    this.token = await MockERC20.new('Stake', 'STK', 18, { from: owner });
-    await this.token.mint(owner, web3.utils.toBN('1000'), { from: owner });
+    this.token = await MockERC20.new('Stake', 'STK', 18, owner, web3.utils.toBN('1000'), { from: owner });
     this.pool = await FeePool.new(this.token.address, burnAddress, { from: owner });
   });
 

--- a/test/integrationScenario.test.js
+++ b/test/integrationScenario.test.js
@@ -16,8 +16,7 @@ contract('Protocol integration scenarios', (accounts) => {
 
   beforeEach(async function () {
     this.identity = await IdentityRegistry.new({ from: deployer });
-    this.token = await MockERC20.new('Stake', 'STK', 18, { from: deployer });
-    await this.token.mint(worker, initialMint, { from: deployer });
+    this.token = await MockERC20.new('Stake', 'STK', 18, worker, initialMint, { from: deployer });
     this.stakeManager = await StakeManager.new(this.token.address, 18, { from: deployer });
     this.feePool = await FeePool.new(this.token.address, feeSink, { from: deployer });
     this.validation = await ValidationModule.new({ from: deployer });

--- a/test/jobRegistry.test.js
+++ b/test/jobRegistry.test.js
@@ -275,8 +275,7 @@ contract('JobRegistry', (accounts) => {
 
   beforeEach(async function () {
     this.identity = await IdentityRegistry.new({ from: deployer });
-    this.token = await MockERC20.new('Stake', 'STK', 18, { from: deployer });
-    await this.token.mint(worker, initialStake, { from: deployer });
+    this.token = await MockERC20.new('Stake', 'STK', 18, worker, initialStake, { from: deployer });
     this.stakeManager = await StakeManager.new(this.token.address, 18, { from: deployer });
     this.feePool = await FeePool.new(this.token.address, burnAddress, { from: deployer });
     this.validation = await ValidationModule.new({ from: deployer });
@@ -779,8 +778,7 @@ contract('JobRegistry', (accounts) => {
   describe('configuration gating', () => {
     beforeEach(async function () {
       this.identity = await IdentityRegistry.new({ from: deployer });
-      this.token = await MockERC20.new('Stake', 'STK', 18, { from: deployer });
-      await this.token.mint(worker, web3.utils.toBN('1000000'), { from: deployer });
+      this.token = await MockERC20.new('Stake', 'STK', 18, worker, web3.utils.toBN('1000000'), { from: deployer });
       this.stakeManager = await StakeManager.new(this.token.address, 18, { from: deployer });
       this.feePool = await FeePool.new(this.token.address, burnAddress, { from: deployer });
       this.validation = await ValidationModule.new({ from: deployer });

--- a/test/mockENSRegistry.test.js
+++ b/test/mockENSRegistry.test.js
@@ -1,0 +1,64 @@
+const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const MockENSRegistry = artifacts.require('MockENSRegistry');
+
+contract('MockENSRegistry', (accounts) => {
+  const [deployer, newOwner, thirdParty] = accounts;
+
+  const ZERO_NODE = '0x' + '0'.repeat(64);
+
+  beforeEach(async function () {
+    this.registry = await MockENSRegistry.new({ from: deployer });
+  });
+
+  it('sets the root owner to the deployer and emits an event', async function () {
+    assert.strictEqual(await this.registry.owner(ZERO_NODE), deployer);
+  });
+
+  it('allows the current owner to update node ownership', async function () {
+    const label = web3.utils.keccak256('node');
+    const creationTx = await this.registry.setSubnodeOwner(ZERO_NODE, label, deployer, { from: deployer });
+    const node = web3.utils.soliditySha3({ type: 'bytes32', value: ZERO_NODE }, { type: 'bytes32', value: label });
+    expectEvent(creationTx, 'Transfer', { node, owner: deployer });
+
+    await expectRevert(
+      this.registry.setOwner(node, newOwner, { from: thirdParty }),
+      'MockENSRegistry: owner'
+    );
+
+    const receipt = await this.registry.setOwner(node, newOwner, { from: deployer });
+    expectEvent(receipt, 'Transfer', { node, owner: newOwner });
+    assert.strictEqual(await this.registry.owner(node), newOwner);
+
+    await expectRevert(
+      this.registry.setOwner(node, deployer, { from: deployer }),
+      'MockENSRegistry: owner'
+    );
+
+    const transferBack = await this.registry.setOwner(node, deployer, { from: newOwner });
+    expectEvent(transferBack, 'Transfer', { node, owner: deployer });
+    assert.strictEqual(await this.registry.owner(node), deployer);
+  });
+
+  it('derives subnode ownership and emits the expected events', async function () {
+    const rootLabel = web3.utils.keccak256('root');
+    const rootTx = await this.registry.setSubnodeOwner(ZERO_NODE, rootLabel, deployer, { from: deployer });
+    const node = web3.utils.soliditySha3(
+      { type: 'bytes32', value: ZERO_NODE },
+      { type: 'bytes32', value: rootLabel }
+    );
+    expectEvent(rootTx, 'Transfer', { node, owner: deployer });
+
+    const label = web3.utils.keccak256('label');
+    const tx = await this.registry.setSubnodeOwner(node, label, newOwner, { from: deployer });
+    const subnode = web3.utils.soliditySha3({ type: 'bytes32', value: node }, { type: 'bytes32', value: label });
+
+    expectEvent(tx, 'Transfer', { node: subnode, owner: newOwner });
+    expectEvent(tx, 'NewOwner', { node, label, owner: newOwner });
+    assert.strictEqual(await this.registry.owner(subnode), newOwner);
+
+    await expectRevert(
+      this.registry.setSubnodeOwner(node, label, deployer, { from: thirdParty }),
+      'MockENSRegistry: owner'
+    );
+  });
+});

--- a/test/mockERC20.test.js
+++ b/test/mockERC20.test.js
@@ -1,0 +1,66 @@
+const { expectEvent, expectRevert, constants, BN } = require('@openzeppelin/test-helpers');
+const MockERC20 = artifacts.require('MockERC20');
+
+contract('MockERC20', (accounts) => {
+  const [deployer, holder, spender, recipient] = accounts;
+  const initialSupply = new BN('1000000');
+
+  beforeEach(async function () {
+    this.token = await MockERC20.new('Mock Token', 'MOCK', 18, holder, initialSupply, { from: deployer });
+  });
+
+  it('initializes metadata and mints to the initial holder', async function () {
+    assert.strictEqual(await this.token.name(), 'Mock Token');
+    assert.strictEqual(await this.token.symbol(), 'MOCK');
+    assert.strictEqual((await this.token.decimals()).toString(), '18');
+    assert.strictEqual((await this.token.totalSupply()).toString(), initialSupply.toString());
+    assert.strictEqual((await this.token.balanceOf(holder)).toString(), initialSupply.toString());
+  });
+
+  it('transfers balances between accounts', async function () {
+    await expectRevert(this.token.transfer(constants.ZERO_ADDRESS, '1', { from: holder }), 'MockERC20: transfer zero');
+
+    const receipt = await this.token.transfer(recipient, '250', { from: holder });
+    expectEvent(receipt, 'Transfer', { from: holder, to: recipient, value: new BN('250') });
+
+    assert.strictEqual((await this.token.balanceOf(holder)).toString(), initialSupply.subn(250).toString());
+    assert.strictEqual((await this.token.balanceOf(recipient)).toString(), '250');
+  });
+
+  it('manages allowances through approvals and adjustments', async function () {
+    await expectRevert(this.token.approve(constants.ZERO_ADDRESS, '1', { from: holder }), 'MockERC20: approve zero');
+
+    const approveReceipt = await this.token.approve(spender, '100', { from: holder });
+    expectEvent(approveReceipt, 'Approval', { owner: holder, spender, value: new BN('100') });
+
+    const increaseReceipt = await this.token.increaseAllowance(spender, '50', { from: holder });
+    expectEvent(increaseReceipt, 'Approval', { owner: holder, spender, value: new BN('150') });
+
+    await expectRevert(
+      this.token.decreaseAllowance(spender, '200', { from: holder }),
+      'MockERC20: allowance'
+    );
+
+    const decreaseReceipt = await this.token.decreaseAllowance(spender, '20', { from: holder });
+    expectEvent(decreaseReceipt, 'Approval', { owner: holder, spender, value: new BN('130') });
+    assert.strictEqual((await this.token.allowance(holder, spender)).toString(), '130');
+  });
+
+  it('spends allowance and preserves infinite approvals', async function () {
+    await this.token.approve(spender, '100', { from: holder });
+    await expectRevert(
+      this.token.transferFrom(holder, recipient, '200', { from: spender }),
+      'MockERC20: allowance'
+    );
+
+    await this.token.transferFrom(holder, recipient, '60', { from: spender });
+    assert.strictEqual((await this.token.allowance(holder, spender)).toString(), '40');
+
+    await this.token.approve(spender, constants.MAX_UINT256, { from: holder });
+    await this.token.transferFrom(holder, recipient, '10', { from: spender });
+    assert.strictEqual(
+      (await this.token.allowance(holder, spender)).toString(),
+      constants.MAX_UINT256.toString()
+    );
+  });
+});

--- a/test/stakeManager.test.js
+++ b/test/stakeManager.test.js
@@ -7,8 +7,7 @@ contract('StakeManager', (accounts) => {
   const initialMint = new BN('1000000');
 
   beforeEach(async function () {
-    this.token = await MockERC20.new('Stake', 'STK', 18, { from: owner });
-    await this.token.mint(staker, initialMint, { from: owner });
+    this.token = await MockERC20.new('Stake', 'STK', 18, staker, initialMint, { from: owner });
     this.manager = await StakeManager.new(this.token.address, 18, { from: owner });
   });
 


### PR DESCRIPTION
## Summary
- add a reusable MockERC20 in the libs package with constructor minting and allowance handling
- introduce a lightweight MockENSRegistry that tracks node and subnode ownership events
- update the Echidna harness and tests to use the new token constructor and remove manual minting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cea375d7448333984f8b4663ff355b