### PR TITLE
Add ENS seeding script for development deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coverage:run": "npx hardhat coverage --testfiles 'test/**/*.js'",
     "coverage:check": "node scripts/check-coverage.js",
     "gas": "REPORT_GAS=true truffle test",
-    "migrate:dev": "truffle migrate --reset --network development",
+    "migrate:dev": "truffle migrate --reset --network development && truffle exec scripts/seed-ens-dev.js --network development",
     "migrate:sepolia": "truffle migrate --reset --network sepolia",
     "verify:sepolia": "truffle run verify IdentityRegistry StakeManager FeePool ValidationModule DisputeModule ReputationEngine CertificateNFT JobRegistry --network sepolia",
     "export:abis": "node scripts/export-abis.js",

--- a/scripts/compute-namehash.js
+++ b/scripts/compute-namehash.js
@@ -3,16 +3,35 @@ const { hash: computeHash } = require('eth-ens-namehash');
 
 const { configPath, readConfig, resolveVariant } = require('./config-loader');
 
-const variant = resolveVariant(process.argv[2]);
+function extractNetwork(argv) {
+  const networkFlagIndex = argv.findIndex((arg) => arg === '--network');
+  if (networkFlagIndex !== -1 && argv[networkFlagIndex + 1]) {
+    return argv[networkFlagIndex + 1];
+  }
+
+  const positional = argv[2];
+  if (positional && !positional.startsWith('--')) {
+    return positional;
+  }
+
+  return undefined;
+}
+
+const variant = resolveVariant(extractNetwork(process.argv));
 const targetPath = configPath('ens', variant);
 const config = readConfig('ens', variant);
 
-if (config.agentRoot) {
-  config.agentRootHash = computeHash(config.agentRoot);
-}
-if (config.clubRoot) {
-  config.clubRootHash = computeHash(config.clubRoot);
-}
+const assignHash = (rootKey, hashKey) => {
+  const value = config[rootKey];
+  if (typeof value === 'string' && value.trim().length > 0) {
+    config[hashKey] = computeHash(value);
+  } else {
+    config[hashKey] = null;
+  }
+};
 
-fs.writeFileSync(targetPath, JSON.stringify(config, null, 2));
+assignHash('agentRoot', 'agentRootHash');
+assignHash('clubRoot', 'clubRootHash');
+
+fs.writeFileSync(targetPath, `${JSON.stringify(config, null, 2)}\n`);
 console.log(`Updated ENS namehashes for ${variant}`);

--- a/scripts/seed-ens-dev.js
+++ b/scripts/seed-ens-dev.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+
+const MockENSRegistry = artifacts.require('MockENSRegistry');
+
+const { hash: namehash } = require('eth-ens-namehash');
+const { configPath, readConfig, resolveVariant } = require('./config-loader');
+
+function extractNetwork(argv) {
+  const networkFlagIndex = argv.findIndex((arg) => arg === '--network');
+  if (networkFlagIndex !== -1 && argv[networkFlagIndex + 1]) {
+    return argv[networkFlagIndex + 1];
+  }
+
+  return undefined;
+}
+
+const labelhash = (label) => {
+  return web3.utils.keccak256(web3.utils.utf8ToHex(label));
+};
+
+module.exports = async function (callback) {
+  try {
+    const networkName = extractNetwork(process.argv) || process.env.TRUFFLE_NETWORK;
+    const variant = resolveVariant(networkName);
+
+    if (variant !== 'dev') {
+      console.log('Skipping ENS seeding for non-development network');
+      callback();
+      return;
+    }
+
+    const registry = await MockENSRegistry.deployed();
+    const accounts = await web3.eth.getAccounts();
+    const owner = accounts[0];
+
+    const rootNode = namehash('');
+    const ethNode = namehash('eth');
+    const agiNode = namehash('agi.eth');
+    const agentNode = namehash('agent.agi.eth');
+    const clubNode = namehash('club.agi.eth');
+
+    const setSubnodeOwner = async (parentNode, label) => {
+      await registry.setSubnodeOwner(parentNode, labelhash(label), owner, { from: owner });
+    };
+
+    await setSubnodeOwner(rootNode, 'eth');
+    await setSubnodeOwner(ethNode, 'agi');
+    await setSubnodeOwner(agiNode, 'agent');
+    await setSubnodeOwner(agiNode, 'club');
+    await setSubnodeOwner(agentNode, 'alice');
+    await setSubnodeOwner(clubNode, 'validator');
+
+    const ensConfigPath = configPath('ens', variant);
+    const ensConfig = readConfig('ens', variant);
+
+    ensConfig.agentRoot = 'agent.agi.eth';
+    ensConfig.clubRoot = 'club.agi.eth';
+    ensConfig.agentRootHash = namehash('agent.agi.eth');
+    ensConfig.clubRootHash = namehash('club.agi.eth');
+
+    fs.writeFileSync(ensConfigPath, `${JSON.stringify(ensConfig, null, 2)}\n`);
+
+    console.log('Seeded MockENSRegistry with local ENS records');
+    callback();
+  } catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+    callback(err);
+  }
+};


### PR DESCRIPTION
## Summary
- extend the ENS namehash helper to accept a target network/variant and clear hashes when roots are undefined
- add a development seeding script that configures the MockENSRegistry with local agent/club records and updates the ENS config
- run the seeding step automatically after `npm run migrate:dev`

## Testing
- npm run namehash

------
https://chatgpt.com/codex/tasks/task_e_68ceb193cb7483339daf3ffe459db3a7