### PR TITLE
Add gas reporting to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       - run: npm run lint:sol
       - run: npm run test
       - run: npm run coverage
+      - run: npm run gas | tee gas-report.txt
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: gas-report
+          path: |
+            gas-report.txt
+            gasReporterOutput.json
+          if-no-files-found: warn
       - run: npm run export:artifacts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coverage": "npx truffle run coverage && COVERAGE_THRESHOLD=90 npm run coverage:check",
     "coverage:run": "npx hardhat coverage --testfiles 'test/**/*.js'",
     "coverage:check": "node scripts/check-coverage.js",
-    "gas": "REPORT_GAS=true truffle test",
+    "gas": "TRUFFLE_TEST=true REPORT_GAS=true node scripts/run-tests.js",
     "dev:prep": "npm run namehash:dev && npx truffle exec scripts/seed-ens-dev.js --network development",
     "migrate:dev": "npx truffle migrate --reset --network development",
     "migrate:mainnet": "npx truffle migrate --reset --network mainnet",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -3,6 +3,19 @@ const HDWalletProvider = require('@truffle/hdwallet-provider');
 
 const { MNEMONIC, RPC_MAINNET, RPC_SEPOLIA, ETHERSCAN_API_KEY } = process.env;
 
+const mocha = { timeout: 600000 };
+
+if (process.env.REPORT_GAS === 'true') {
+  mocha.reporter = 'eth-gas-reporter';
+  mocha.reporterOptions = {
+    currency: 'USD',
+    gasPrice: 30,
+    noColors: true,
+    showTimeSpent: true,
+    excludeContracts: ['Migrations'],
+  };
+}
+
 module.exports = {
   plugins: ['truffle-plugin-verify', 'truffle-hardhat-coverage'],
   api_keys: { etherscan: ETHERSCAN_API_KEY },
@@ -29,5 +42,5 @@ module.exports = {
       settings: { optimizer: { enabled: true, runs: 600 } }
     }
   },
-  mocha: { timeout: 600000 }
+  mocha
 };


### PR DESCRIPTION
## Summary
- run the gas reporting test suite in CI and upload the resulting report artifacts
- ensure the gas npm script spins up the Hardhat test node and uses eth-gas-reporter for deterministic output

## Testing
- npm run gas

------
https://chatgpt.com/codex/tasks/task_e_68cebdcb6ec48333bf109c2cd146ce82