### PR TITLE
Add scheduled Echidna long fuzzing

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -5,9 +5,12 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   fuzz:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
@@ -58,3 +61,66 @@ jobs:
             ./contracts/core/EchidnaJobRegistryInvariants.sol \
             --contract EchidnaJobRegistryInvariants \
             --config tools/echidna.yaml
+
+  fuzz-long:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Install Echidna
+        run: |
+          set -euxo pipefail
+          sudo add-apt-repository ppa:ethereum/ethereum -y
+          sudo apt-get update
+          if ! sudo apt-get install -y echidna-test; then
+            echo "apt package unavailable, downloading latest release"
+            arch=$(dpkg --print-architecture)
+            case "$arch" in
+              amd64) asset_arch=x86_64-linux ;;
+              arm64) asset_arch=aarch64-linux ;;
+              *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+            esac
+
+            tmpdir=$(mktemp -d)
+            asset_url=$(curl -fsSL https://api.github.com/repos/crytic/echidna/releases/latest \
+              | grep browser_download_url \
+              | grep "$asset_arch" \
+              | head -n 1 \
+              | cut -d '"' -f 4)
+            if [ -z "$asset_url" ]; then
+              echo "Unable to locate Echidna release asset for $asset_arch" >&2
+              exit 1
+            fi
+            curl -fsSL "$asset_url" -o "$tmpdir/echidna.tar.gz"
+            tar -xzf "$tmpdir/echidna.tar.gz" -C "$tmpdir"
+            sudo install -m 0755 "$tmpdir/echidna" /usr/local/bin/echidna-test
+            rm -rf "$tmpdir"
+          fi
+
+          user_base=$(python3 -m site --user-base)
+          python3 -m pip install --user crytic-compile
+          echo "$user_base/bin" >> "$GITHUB_PATH"
+          export PATH="$user_base/bin:$PATH"
+          solc-select install 0.8.23
+          solc-select use 0.8.23
+      - name: Run Echidna long fuzzing
+        run: |
+          set -euxo pipefail
+          mkdir -p artifacts/echidna-long/corpus
+          echidna-test \
+            ./contracts/core/EchidnaJobRegistryInvariants.sol \
+            --contract EchidnaJobRegistryInvariants \
+            --config tools/echidna-long.yaml \
+            | tee artifacts/echidna-long/echidna.log
+      - name: Upload Echidna long-run artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: echidna-long-${{ github.run_id }}
+          path: |
+            artifacts/echidna-long/echidna.log
+            artifacts/echidna-long/corpus

--- a/tools/echidna-long.yaml
+++ b/tools/echidna-long.yaml
@@ -1,0 +1,5 @@
+testMode: assertion
+seed: 1
+testLimit: 50000
+contract: EchidnaJobRegistryInvariants
+corpusDir: artifacts/echidna-long/corpus


### PR DESCRIPTION
## Summary
- add a nightly scheduled trigger dedicated to long-running Echidna fuzzing
- introduce a long-run configuration and upload its corpus and log artifacts for reuse

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cec063f3bc83339d5a8ab41f1b99cd