### PR TITLE
Use Slither Docker image in workflow

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -15,17 +15,17 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
+      - name: Prepare Hardhat directories
+        run: |
+          mkdir -p cache artifacts artifacts/build-info
+          chmod -R 777 cache artifacts
       - name: Run Slither
         run: |
           NODE_DIR="$(dirname "$(dirname "$(node -p 'process.execPath')")")"
-          USER_ID="$(id -u)"
-          GROUP_ID="$(id -g)"
           docker run --rm \
             -v ${{ github.workspace }}:/src \
             -v "${NODE_DIR}":"${NODE_DIR}" \
             -w /src \
             -e NODE_DIR="${NODE_DIR}" \
-            -e HOME=/src \
-            --user "${USER_ID}:${GROUP_ID}" \
             ghcr.io/crytic/slither:0.10.4 \
             sh -lc 'export PATH="/src/node_modules/.bin:$NODE_DIR/bin:$PATH"; slither . --fail-medium'

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: docker run --rm -v ${{ github.workspace }}:/src -w /src trailofbits/slither:latest --fail-medium .
+        run: docker run --rm -v ${{ github.workspace }}:/src -w /src trailofbits/slither:latest slither --fail-medium .

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,9 +16,4 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/src \
-            -w /src \
-            trailofbits/slither:latest \
-            sh -c "python3 -m pip install --no-cache-dir 'slither-analyzer>=0.10.4' && slither . --fail-medium"
+        run: docker run --rm -v ${{ github.workspace }}:/src trailofbits/slither:latest slither /src --fail-medium

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: docker run --rm -v ${{ github.workspace }}:/src trailofbits/slither:latest slither /src --fail-medium
+        run: docker run --rm -v ${{ github.workspace }}:/src -w /src ghcr.io/crytic/slither:0.10.4 slither . --fail-medium

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: docker run --rm -v ${{ github.workspace }}:/src trailofbits/slither:latest slither /src --fail-medium
+        run: docker run --rm -v ${{ github.workspace }}:/src -w /src trailofbits/slither:latest --fail-medium .

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: docker run --rm -v ${{ github.workspace }}:/src -w /src trailofbits/slither:latest slither --fail-medium .
+        run: docker run --rm -v ${{ github.workspace }}:/src -w /src trailofbits/slither:0.10.4 sh -c "slither . --fail-medium"

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -18,10 +18,14 @@ jobs:
       - name: Run Slither
         run: |
           NODE_DIR="$(dirname "$(dirname "$(node -p 'process.execPath')")")"
+          USER_ID="$(id -u)"
+          GROUP_ID="$(id -g)"
           docker run --rm \
             -v ${{ github.workspace }}:/src \
             -v "${NODE_DIR}":"${NODE_DIR}" \
             -w /src \
             -e NODE_DIR="${NODE_DIR}" \
+            -e HOME=/src \
+            --user "${USER_ID}:${GROUP_ID}" \
             ghcr.io/crytic/slither:0.10.4 \
             sh -lc 'export PATH="/src/node_modules/.bin:$NODE_DIR/bin:$PATH"; slither . --fail-medium'

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,9 +16,9 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: >-
+        run: |
           docker run --rm \
-          -v ${{ github.workspace }}:/src \
-          -w /src \
-          trailofbits/slither:latest \
-          sh -c "python3 -m pip install --no-cache-dir 'slither-analyzer>=0.10.4' && slither . --fail-medium"
+            -v ${{ github.workspace }}:/src \
+            -w /src \
+            trailofbits/slither:latest \
+            sh -c "python3 -m pip install --no-cache-dir 'slither-analyzer>=0.10.4' && slither . --fail-medium"

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -15,7 +15,5 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - name: Install Slither
-        run: pip install slither-analyzer==0.10.3
       - name: Run Slither
-        run: slither . --fail-medium
+        run: docker run --rm -v ${{ github.workspace }}:/src trailofbits/slither:latest slither /src --fail-medium

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,4 +16,9 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: docker run --rm -v ${{ github.workspace }}:/src -w /src trailofbits/slither:0.10.4 sh -c "slither . --fail-medium"
+        run: >-
+          docker run --rm \
+          -v ${{ github.workspace }}:/src \
+          -w /src \
+          trailofbits/slither:latest \
+          sh -c "python3 -m pip install --no-cache-dir 'slither-analyzer>=0.10.4' && slither . --fail-medium"

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -16,4 +16,12 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: Run Slither
-        run: docker run --rm -v ${{ github.workspace }}:/src -w /src ghcr.io/crytic/slither:0.10.4 slither . --fail-medium
+        run: |
+          NODE_DIR="$(dirname "$(dirname "$(node -p 'process.execPath')")")"
+          docker run --rm \
+            -v ${{ github.workspace }}:/src \
+            -v "${NODE_DIR}":"${NODE_DIR}" \
+            -w /src \
+            -e NODE_DIR="${NODE_DIR}" \
+            ghcr.io/crytic/slither:0.10.4 \
+            sh -lc 'export PATH="/src/node_modules/.bin:$NODE_DIR/bin:$PATH"; slither . --fail-medium'


### PR DESCRIPTION
## Summary
- update the Slither GitHub Actions workflow to run the analyzer from the official Docker image
- remove the now unnecessary Python-based Slither installation step while keeping npm dependencies installed

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cec15a9e188333accd0f28d56925a5