### PR TITLE
Add truffle flattener script and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,9 @@ web_modules/
 coverage.json
 
 # Exported deployment artifacts
-artifacts-public/
+artifacts-public/*
+!artifacts-public/flat/
+!artifacts-public/flat/.gitkeep
 artifacts/
 cache/
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ npm run export:artifacts
 
 `npm run export:artifacts` performs a deterministic local migration, exports network-specific addresses, and generates sanitized ABI bundles under `artifacts-public/`. Use `npm run export:abis` when you only need to refresh the ABI manifest after a compile.
 
+## Flatten contracts
+
+Generate single-file Solidity sources for third-party verifiers with the helper script:
+
+```bash
+./scripts/flatten.sh
+```
+
+The script writes flattened sources to `artifacts-public/flat/`, reusing the repository's local `truffle-flattener` installation. If the script is unavailable in your shell, fall back to the underlying command:
+
+```bash
+npx truffle-flattener <path-to-contract> > artifacts-public/flat/<Contract>.flat.sol
+```
+
 ## Verify wiring
 
 Run the wiring checker to confirm deployed contract addresses match the expected configuration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "solhint": "^3.6.2",
         "solidity-coverage": "^0.8.16",
         "truffle": "^5.11.5",
+        "truffle-flattener": "^1.6.0",
         "truffle-hardhat-coverage": "file:tools/truffle-hardhat-coverage",
         "truffle-plugin-verify": "^0.6.0"
       }
@@ -2960,6 +2961,92 @@
       "integrity": "sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@resolver-engine/core": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/core/-/core-0.2.1.tgz",
+      "integrity": "sha512-nsLQHmPJ77QuifqsIvqjaF5B9aHnDzJjp73Q1z6apY3e9nqYrx4Dtowhpsf7Jwftg/XzVDEMQC+OzUBNTS+S1A==",
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "request": "^2.85.0"
+      }
+    },
+    "node_modules/@resolver-engine/core/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@resolver-engine/fs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/fs/-/fs-0.2.1.tgz",
+      "integrity": "sha512-7kJInM1Qo2LJcKyDhuYzh9ZWd+mal/fynfL9BNjWOiTcOpX+jNfqb/UmGUqros5pceBITlWGqS4lU709yHFUbg==",
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/@resolver-engine/fs/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@resolver-engine/imports": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports/-/imports-0.2.2.tgz",
+      "integrity": "sha512-u5/HUkvo8q34AA+hnxxqqXGfby5swnH0Myw91o3Sm2TETJlNKXibFGSKBavAH+wvWdBi4Z5gS2Odu0PowgVOUg==",
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@resolver-engine/core": "^0.2.1",
+        "debug": "^3.1.0",
+        "hosted-git-info": "^2.6.0"
+      }
+    },
+    "node_modules/@resolver-engine/imports-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@resolver-engine/imports-fs/-/imports-fs-0.2.2.tgz",
+      "integrity": "sha512-gFCgMvCwyppjwq0UzIjde/WI+yDs3oatJhozG9xdjJdewwtd7LiF0T5i9lrHAUtqrQbqoFE4E+ZMRVHWpWHpKQ==",
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@resolver-engine/fs": "^0.2.1",
+        "@resolver-engine/imports": "^0.2.2",
+        "debug": "^3.1.0"
+      }
+    },
+    "node_modules/@resolver-engine/imports-fs/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@resolver-engine/imports/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/@scure/base": {
       "version": "1.1.9",
@@ -14496,7 +14583,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "extraneous": true,
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -25355,6 +25441,109 @@
       },
       "optionalDependencies": {
         "@truffle/db": "^2.0.36"
+      }
+    },
+    "node_modules/truffle-flattener": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.6.0.tgz",
+      "integrity": "sha512-scS5Bsi4CZyvlrmD4iQcLHTiG2RQFUXVheTgWeH6PuafmI+Lk5U87Es98loM3w3ImqC9/fPHq+3QIXbcPuoJ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@resolver-engine/imports-fs": "^0.2.2",
+        "@solidity-parser/parser": "^0.14.1",
+        "find-up": "^2.1.0",
+        "mkdirp": "^1.0.4",
+        "tsort": "0.0.1"
+      },
+      "bin": {
+        "truffle-flattener": "index.js"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/truffle-flattener/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/truffle-hardhat-coverage": {

--- a/package.json
+++ b/package.json
@@ -30,21 +30,22 @@
   "devDependencies": {
     "@commitlint/cli": "^19.0.3",
     "@commitlint/config-conventional": "^19.0.3",
+    "@nomiclabs/hardhat-truffle5": "^2.1.0",
+    "@openzeppelin/test-helpers": "^0.5.16",
     "@truffle/hdwallet-provider": "^2.1.14",
     "dotenv": "^16.4.5",
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.2.27",
+    "hardhat": "^2.17.2",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.0",
     "prettier": "^3.3.3",
     "solhint": "^3.6.2",
     "solidity-coverage": "^0.8.16",
     "truffle": "^5.11.5",
-    "truffle-plugin-verify": "^0.6.0",
+    "truffle-flattener": "^1.6.0",
     "truffle-hardhat-coverage": "file:tools/truffle-hardhat-coverage",
-    "@openzeppelin/test-helpers": "^0.5.16",
-    "hardhat": "^2.17.2",
-    "@nomiclabs/hardhat-truffle5": "^2.1.0"
+    "truffle-plugin-verify": "^0.6.0"
   },
   "lint-staged": {
     "*.{js,json,md,yml,yaml}": [

--- a/scripts/flatten.sh
+++ b/scripts/flatten.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="artifacts-public/flat"
+CONTRACTS_DIR="contracts"
+
+mkdir -p "${OUTPUT_DIR}"
+
+shopt -s nullglob
+contracts=("${CONTRACTS_DIR}"/*.sol)
+
+if [ ${#contracts[@]} -eq 0 ]; then
+  echo "No Solidity contracts found in ${CONTRACTS_DIR}."
+  exit 0
+fi
+
+for contract in "${contracts[@]}"; do
+  filename=$(basename "${contract}")
+  flat_name="${filename%.sol}.flat.sol"
+  echo "Flattening ${contract} -> ${OUTPUT_DIR}/${flat_name}"
+  npx --yes truffle-flattener "${contract}" > "${OUTPUT_DIR}/${flat_name}"
+done
+


### PR DESCRIPTION
## Summary
- add truffle-flattener as a development dependency and expose a flattening helper script
- ensure flattened artifacts have a tracked output directory
- document the new workflow and npx fallback for flattening contracts

## Testing
- `npm run lint:sol`


------
https://chatgpt.com/codex/tasks/task_e_68ced08eb20083338e7907bdd10a2bca