### PR TITLE
Update burn address to governance destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ in `config/agialpha.mainnet.json` and `config/ens.mainnet.json` before migrating
 | ------------------------- | -------------------------------------------------------------------------------------- |
 | Stake token (`$AGIALPHA`) | `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`                                           |
 | Token decimals            | `18`                                                                                   |
-| Stake burn address        | `0x000000000000000000000000000000000000dEaD`                                           |
+| Stake burn address        | `0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000`                                           |
 | ENS registry              | `0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e`                                           |
 | Agent ENS root            | `agent.agi.eth` (`0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d`) |
 | Club ENS root             | `club.agi.eth` (`0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16`)  |

--- a/config/agialpha.dev.json
+++ b/config/agialpha.dev.json
@@ -1,5 +1,5 @@
 {
   "token": "mock",
   "decimals": 18,
-  "burnAddress": "0x000000000000000000000000000000000000dEaD"
+  "burnAddress": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000"
 }

--- a/config/agialpha.mainnet.json
+++ b/config/agialpha.mainnet.json
@@ -1,5 +1,5 @@
 {
   "token": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
   "decimals": 18,
-  "burnAddress": "0x000000000000000000000000000000000000dEaD"
+  "burnAddress": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000"
 }


### PR DESCRIPTION
## Summary
- point the agialpha configs at the governance-approved burn destination
- document the new burn address in the mainnet deployment profile

## Testing
- GOV_SAFE=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 npm run migrate:dev
- npm run wire:verify

------
https://chatgpt.com/codex/tasks/task_e_68ced9d77d1083338f9a487e50326740