### PR TITLE
Ensure staking fee recipient matches fee pool

### DIFF
--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -83,6 +83,11 @@ module.exports = async function (callback) {
     );
 
     expectEq(await staking.jobRegistry(), jobRegistry.address, 'staking.jobRegistry');
+    expectEq(
+      await staking.feeRecipient(),
+      feePool.address,
+      'staking.feeRecipient'
+    );
     expectEq(await feePool.jobRegistry(), jobRegistry.address, 'feePool.jobRegistry');
     expectEq(await dispute.jobRegistry(), jobRegistry.address, 'dispute.jobRegistry');
     expectEq(await reputation.jobRegistry(), jobRegistry.address, 'reputation.jobRegistry');


### PR DESCRIPTION
## Summary
- verify that the stake manager fee recipient matches the deployed fee pool address during wiring checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee1a544048333a691ecd857085b87