### PR TITLE
Verify job timings during wiring check

### DIFF
--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -100,6 +100,17 @@ module.exports = async function (callback) {
       throw new Error('slashBpsMax mismatch');
     }
 
+    const timings = await jobRegistry.timings();
+    if (Number(timings.commitWindow) !== params.commitWindow) {
+      throw new Error('commitWindow mismatch');
+    }
+    if (Number(timings.revealWindow) !== params.revealWindow) {
+      throw new Error('revealWindow mismatch');
+    }
+    if (Number(timings.disputeWindow) !== params.disputeWindow) {
+      throw new Error('disputeWindow mismatch');
+    }
+
     console.log('WIRING OK');
     callback();
   } catch (err) {


### PR DESCRIPTION
## Summary
- load the job registry lifecycle timing configuration during wiring verification
- compare each timing window against the expected values in config/params.json

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee292b4b08333ad6392d1fdb66d7c