### PR TITLE
Add Codecov coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
       - run: npm run lint:sol
       - run: npm run test
       - run: npm run coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
+        with:
+          files: coverage/lcov.info
+          flags: solidity
+          name: solidity-coverage
+          fail_ci_if_error: true
       - run: npm run gas | tee gas-report.txt
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AGIJobsv1 — Protocol-Only (Truffle)
 
+[![Coverage](https://codecov.io/gh/agi-protocol/AGIJobsv1/branch/main/graph/badge.svg)](https://codecov.io/gh/agi-protocol/AGIJobsv1)
+
 Institutional-grade, ENS-gated job coordination protocol. Contracts only: Solidity, Truffle migrations, tests, CI.
 
 ## Quickstart
@@ -11,7 +13,8 @@ npm run test
 npm run coverage
 ```
 
-`npm run coverage` enforces a 90% minimum threshold across lines, branches, and functions to match our CI gate.
+`npm run coverage` enforces a 90% minimum threshold across lines, branches, and functions to match our CI gate. The CI workflow
+uploads `coverage/lcov.info` to Codecov so the badge above reflects the latest main-branch run automatically.
 
 ## Configure
 


### PR DESCRIPTION
## Summary
- upload the LCOV report from the CI workflow to Codecov using a pinned action commit
- surface the Codecov coverage badge at the top of the README and describe how it stays current

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cee5e1bad48333a6f8b5e6f66226c1