### PR TITLE
Update ENS seeding ownership assignments

### DIFF
--- a/scripts/seed-ens-dev.js
+++ b/scripts/seed-ens-dev.js
@@ -39,16 +39,17 @@ module.exports = async function (callback) {
     const agentNode = namehash('agent.agi.eth');
     const clubNode = namehash('club.agi.eth');
 
-    const setSubnodeOwner = async (parentNode, label) => {
-      await registry.setSubnodeOwner(parentNode, labelhash(label), owner, { from: owner });
+    const setSubnodeOwner = async (parentNode, label, newOwner = owner, domainName = label) => {
+      await registry.setSubnodeOwner(parentNode, labelhash(label), newOwner, { from: owner });
+      console.log(`Assigned ${domainName} to ${newOwner}`);
     };
 
-    await setSubnodeOwner(rootNode, 'eth');
-    await setSubnodeOwner(ethNode, 'agi');
-    await setSubnodeOwner(agiNode, 'agent');
-    await setSubnodeOwner(agiNode, 'club');
-    await setSubnodeOwner(agentNode, 'alice');
-    await setSubnodeOwner(clubNode, 'validator');
+    await setSubnodeOwner(rootNode, 'eth', owner, 'eth');
+    await setSubnodeOwner(ethNode, 'agi', owner, 'agi.eth');
+    await setSubnodeOwner(agiNode, 'agent', owner, 'agent.agi.eth');
+    await setSubnodeOwner(agiNode, 'club', owner, 'club.agi.eth');
+    await setSubnodeOwner(agentNode, 'alice', accounts[1], 'alice.agent.agi.eth');
+    await setSubnodeOwner(clubNode, 'validator', accounts[2], 'validator.club.agi.eth');
 
     const ensConfigPath = configPath('ens', variant);
     const ensConfig = readConfig('ens', variant);


### PR DESCRIPTION
## Summary
- allow the ENS seeding helper to accept a custom owner so child identities can belong to different accounts
- keep root ownership with the default deployer while assigning alice.agent.agi.eth and validator.club.agi.eth to dedicated dev accounts
- log assigned owners for each seeded node to make it easy to confirm the updates

## Testing
- npx hardhat node
- GOV_SAFE=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 npx truffle migrate --reset --network development
- npx truffle exec --network development scripts/seed-ens-dev.js

------
https://chatgpt.com/codex/tasks/task_e_68cef0189bcc8333b24d37165c01cad0