### PR TITLE
Map test networks to development config variant

### DIFF
--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -7,12 +7,25 @@ function resolveVariant(networkOrVariant = DEFAULT_VARIANT) {
   if (!networkOrVariant) {
     return DEFAULT_VARIANT;
   }
-  if (networkOrVariant === 'development' || networkOrVariant === 'dev') {
-    return 'dev';
-  }
-  if (networkOrVariant === 'mainnet') {
+
+  const normalized = networkOrVariant.toLowerCase();
+
+  if (normalized === 'mainnet') {
     return 'mainnet';
   }
+
+  const devVariants = new Set([
+    'dev',
+    'development',
+    'localhost',
+    'hardhat',
+    'sepolia'
+  ]);
+
+  if (devVariants.has(normalized)) {
+    return 'dev';
+  }
+
   return DEFAULT_VARIANT;
 }
 


### PR DESCRIPTION
## Summary
- normalize network names when resolving configuration variants
- map sepolia, hardhat, and other development-style networks to the dev configuration

## Testing
- `MNEMONIC="test test test test test test test test test test test junk" RPC_SEPOLIA="http://127.0.0.1:8545" npx truffle migrate --network sepolia --dry-run` *(fails: missing JSON-RPC endpoint / local chain id mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68cef31474108333a5e8913b219ab74b