### PR TITLE
Add threshold parameter validation in wiring script

### DIFF
--- a/scripts/verify-wiring.js
+++ b/scripts/verify-wiring.js
@@ -99,6 +99,15 @@ module.exports = async function (callback) {
     if (Number(thresholds.slashBpsMax) !== params.slashBpsMax) {
       throw new Error('slashBpsMax mismatch');
     }
+    if (Number(thresholds.approvalThresholdBps) !== params.approvalThresholdBps) {
+      throw new Error('approvalThresholdBps mismatch');
+    }
+    if (Number(thresholds.quorumMin) !== params.quorumMin) {
+      throw new Error('quorumMin mismatch');
+    }
+    if (Number(thresholds.quorumMax) !== params.quorumMax) {
+      throw new Error('quorumMax mismatch');
+    }
 
     const timings = await jobRegistry.timings();
     if (Number(timings.commitWindow) !== params.commitWindow) {


### PR DESCRIPTION
## Summary
- ensure verify-wiring script compares approvalThresholdBps, quorumMin, and quorumMax against configuration values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cef40c973083339b2cb369ce98a1c8