### PR TITLE
Add bounds check for approval threshold BPS

### DIFF
--- a/contracts/core/EchidnaJobRegistryInvariants.sol
+++ b/contracts/core/EchidnaJobRegistryInvariants.sol
@@ -339,6 +339,7 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
         return
             thresholds.quorumMin > 0 &&
             thresholds.quorumMin <= thresholds.quorumMax &&
+            thresholds.approvalThresholdBps <= denominator &&
             thresholds.feeBps <= denominator &&
             thresholds.slashBpsMax <= denominator;
     }

--- a/contracts/core/JobRegistry.sol
+++ b/contracts/core/JobRegistry.sol
@@ -146,6 +146,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         uint256 slashBpsMax
     ) external onlyOwner {
         require(quorumMin > 0 && quorumMax >= quorumMin, "JobRegistry: quorum");
+        require(approvalThresholdBps <= BPS_DENOMINATOR, "JobRegistry: approval bps");
         require(feeBps <= BPS_DENOMINATOR, "JobRegistry: fee bps");
         require(slashBpsMax <= BPS_DENOMINATOR, "JobRegistry: slash bps");
 

--- a/test/jobRegistry.test.js
+++ b/test/jobRegistry.test.js
@@ -628,6 +628,10 @@ contract('JobRegistry', (accounts) => {
       'JobRegistry: quorum'
     );
     await expectRevert(
+      this.jobRegistry.setThresholds(12000, 1, 11, 250, 2000, { from: deployer }),
+      'JobRegistry: approval bps'
+    );
+    await expectRevert(
       this.jobRegistry.setThresholds(6000, 1, 11, 20000, 2000, { from: deployer }),
       'JobRegistry: fee bps'
     );


### PR DESCRIPTION
## Summary
- enforce `approvalThresholdBps` to stay within the 10,000 BPS denominator so governance cannot misconfigure thresholds
- extend the Echidna invariant harness and unit test suite to cover the new guard

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf01f4c6f483339c513792d9e45c72