### PR TITLE
Require disputed jobs to resolve through dispute flow

### DIFF
--- a/contracts/core/JobRegistry.sol
+++ b/contracts/core/JobRegistry.sol
@@ -219,9 +219,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
         _requireModulesConfigured();
         _requireThresholdsConfigured();
         Job storage job = jobs[jobId];
-        if (job.state != JobState.Revealed && job.state != JobState.Disputed) {
-            revert InvalidState(JobState.Revealed, job.state);
-        }
+        _requireState(job.state, JobState.Revealed);
 
         uint256 feeAmount = (job.stakeAmount * thresholds.feeBps) / BPS_DENOMINATOR;
         if (feeAmount > job.stakeAmount) revert FeeBounds();


### PR DESCRIPTION
## Summary
- ensure `JobRegistry.finalizeJob` only executes when a job is in the Revealed state so disputes cannot bypass the resolution path
- add a regression test that verifies disputed jobs must be closed with `resolveDispute`

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf06c660588333a7af38dce1a4fe9e