### PR TITLE
Guard dispute resolution against inconsistent slash parameters

### DIFF
--- a/contracts/core/JobRegistry.sol
+++ b/contracts/core/JobRegistry.sol
@@ -73,6 +73,7 @@ contract JobRegistry is Ownable, ReentrancyGuard {
     error FeeBounds();
     error NotConfigured(bytes32 component);
     error UnauthorizedDisputeRaiser(uint256 jobId, address caller);
+    error SlashAmountWithoutSlashing();
 
     bytes32 private constant MODULES_KEY = "modules";
     bytes32 private constant TIMINGS_KEY = "timings";
@@ -286,6 +287,9 @@ contract JobRegistry is Ownable, ReentrancyGuard {
                 feePool.recordFee(slashAmount);
             }
         } else {
+            if (slashAmount > 0) {
+                revert SlashAmountWithoutSlashing();
+            }
             staking.releaseStake(job.worker, job.stakeAmount);
         }
 

--- a/test/jobRegistry.test.js
+++ b/test/jobRegistry.test.js
@@ -40,6 +40,7 @@ const CUSTOM_ERROR_TYPES = {
   InvalidState: ['uint8', 'uint8'],
   WindowExpired: ['string'],
   FeeBounds: [],
+  SlashAmountWithoutSlashing: [],
 };
 
 const JOB_STATES = {
@@ -427,6 +428,11 @@ contract('JobRegistry', (accounts) => {
     await expectRevert(
       this.jobRegistry.resolveDispute(jobId, true, web3.utils.toBN('600'), 0, { from: deployer }),
       'JobRegistry: slash bounds'
+    );
+
+    await expectCustomError(
+      this.jobRegistry.resolveDispute(jobId, false, 1, 0, { from: deployer }),
+      'JobRegistry.SlashAmountWithoutSlashing()'
     );
 
     const resolveTx = await this.jobRegistry.resolveDispute(jobId, false, 0, 3, {


### PR DESCRIPTION
## Summary
- add a dedicated custom error in `JobRegistry` to forbid providing a non-zero slash amount when `slashWorker` is false
- update the dispute precondition test coverage to assert the new guard and register the error for custom error decoding helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf097b4f408333adc2fc91e0d5f6e0