### PR TITLE
Enhance wiring verifier with token and ENS checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Run the wiring checker to confirm deployed contract addresses match the expected
 npm run wire:verify
 ```
 
+The checker now enforces the stake token wiring and ENS configuration in addition to ownership. It cross-references `config/agialpha.*.json` and `config/ens.*.json` so production runs fail fast if the contracts are bound to the wrong `$AGIALPHA` token, burn address, or ENS roots.
+
 The script defaults to the local development network. Override it by setting `NETWORK` before invoking the command, for example:
 
 ```bash

--- a/docs/mainnet-deployment-simulation.md
+++ b/docs/mainnet-deployment-simulation.md
@@ -41,7 +41,9 @@ pre-flight checklist before running against the live network.
    spot-check critical reads such as `StakeManager.stakeToken()` or ENS roots via
    `truffle console --network mainnet`. Because the simulation lacked a real RPC
    endpoint, no stateful checks were executed; instead, the wiring script logic
-   was reviewed to ensure it enforces the Safe and timelock ownership rules.【F:scripts/verify-wiring.js†L1-L82】
+   was reviewed to ensure it enforces the Safe/timelock ownership rules **and**
+   now fails if the deployed `$AGIALPHA` token, burn sink, or ENS node hashes
+   diverge from the JSON configuration.【F:scripts/verify-wiring.js†L1-L159】
 
 Update this section with transaction hashes, verification links, and console
 outputs once the live deployment completes.


### PR DESCRIPTION
## Summary
- extend the wiring verification script to load network-specific configuration and assert stake token, burn sink, and ENS node bindings
- document the stricter checks in the README and mainnet deployment simulation guide

## Testing
- npm test
- npm run wire:verify

------
https://chatgpt.com/codex/tasks/task_e_68cf12b84c508333ac4424e0a4d7698b