### PR TITLE
Add configuration validation guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm ci
 npm run build
 npm run test
 npm run coverage
+npm run config:validate
 ```
 
 `npm run coverage` enforces a 90% minimum threshold across lines, branches, and functions to match our CI gate. When the CI workflow has access to the repository `CODECOV_TOKEN` secret (for pushes and internal branches), it uploads `coverage/lcov.info` to Codecov so the badge above reflects the latest main-branch run automatically, even for private mirrors; forked pull requests skip the upload without failing the build.
@@ -30,6 +31,8 @@ Edit configuration files under `config/` to match the deployment environment:
   `npm run namehash -- <variant>` or `node scripts/compute-namehash.js <path-to-config>`; the variant command defaults to
   `mainnet`).
 - `config/params.json` — Commit/reveal/dispute windows and governance thresholds.
+- Run `npm run config:validate` after editing to confirm addresses, namehashes, and governance parameters satisfy production
+  guardrails before broadcasting migrations.
 
 ### Manual verification: ENS namehash script
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "namehash": "node scripts/compute-namehash.js",
     "namehash:dev": "node scripts/compute-namehash.js dev",
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",
+    "config:validate": "node scripts/validate-config.js",
     "prepare": "husky install",
     "hardhat:test": "node scripts/run-tests.js"
   },

--- a/scripts/validate-config.js
+++ b/scripts/validate-config.js
@@ -1,0 +1,275 @@
+const fs = require('fs');
+const path = require('path');
+const { hash: namehash } = require('eth-ens-namehash');
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const AGI_MAINNET_TOKEN = '0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA';
+const AGI_MAINNET_BURN = '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000';
+const ENS_MAINNET_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
+const HEX_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
+
+function readJson(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function isAddress(value) {
+  return typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value);
+}
+
+function equalsIgnoreCase(a, b) {
+  return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+}
+
+function addError(errors, fileLabel, message) {
+  errors.push(`${fileLabel}: ${message}`);
+}
+
+function ensureInteger(errors, fileLabel, object, key, { min, max, positive } = {}) {
+  const value = object[key];
+  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) {
+    addError(errors, fileLabel, `${key} must be an integer number`);
+    return null;
+  }
+
+  if (positive && value <= 0) {
+    addError(errors, fileLabel, `${key} must be greater than zero`);
+  }
+
+  if (typeof min === 'number' && value < min) {
+    addError(errors, fileLabel, `${key} must be at least ${min}`);
+  }
+
+  if (typeof max === 'number' && value > max) {
+    addError(errors, fileLabel, `${key} must be at most ${max}`);
+  }
+
+  return value;
+}
+
+function validateAddress(errors, fileLabel, value, { allowZero = false, field }) {
+  if (typeof value !== 'string') {
+    addError(errors, fileLabel, `${field} must be a string address`);
+    return;
+  }
+
+  if (!isAddress(value)) {
+    addError(errors, fileLabel, `${field} must be a valid 0x-prefixed address`);
+    return;
+  }
+
+  if (!allowZero && equalsIgnoreCase(value, ZERO_ADDRESS)) {
+    addError(errors, fileLabel, `${field} must not be the zero address`);
+  }
+}
+
+function validateAgiAlphaConfig(errors, fileLabel, data, { variant }) {
+  if (!data || typeof data !== 'object') {
+    addError(errors, fileLabel, 'configuration must be an object');
+    return;
+  }
+
+  const token = data.token;
+  if (variant === 'mainnet') {
+    validateAddress(errors, fileLabel, token, { field: 'token' });
+    if (typeof token === 'string' && !equalsIgnoreCase(token, AGI_MAINNET_TOKEN)) {
+      addError(
+        errors,
+        fileLabel,
+        `token must equal ${AGI_MAINNET_TOKEN} for mainnet deployments`
+      );
+    }
+  } else if (typeof token === 'string' && token.toLowerCase() !== 'mock') {
+    validateAddress(errors, fileLabel, token, { field: 'token', allowZero: false });
+  }
+
+  const decimals = ensureInteger(errors, fileLabel, data, 'decimals', { min: 0, max: 255 });
+  if (decimals !== null && variant === 'mainnet' && decimals !== 18) {
+    addError(errors, fileLabel, 'decimals must be 18 for the production token');
+  }
+
+  const burnAddress = data.burnAddress;
+  validateAddress(errors, fileLabel, burnAddress, { field: 'burnAddress' });
+  if (typeof burnAddress === 'string' && variant === 'mainnet') {
+    if (!equalsIgnoreCase(burnAddress, AGI_MAINNET_BURN)) {
+      addError(errors, fileLabel, `burnAddress must equal ${AGI_MAINNET_BURN} on mainnet`);
+    }
+  }
+}
+
+function validateEnsRoot(errors, fileLabel, data, rootKey, hashKey, { required }) {
+  const root = data[rootKey];
+  const hash = data[hashKey];
+
+  if (root === null || root === undefined) {
+    if (required) {
+      addError(errors, fileLabel, `${rootKey} must be specified`);
+    }
+    if (hash !== null && hash !== undefined) {
+      addError(errors, fileLabel, `${hashKey} must be null when ${rootKey} is not set`);
+    }
+    return;
+  }
+
+  if (typeof root !== 'string' || root.trim().length === 0) {
+    addError(errors, fileLabel, `${rootKey} must be a non-empty string`);
+    return;
+  }
+
+  if (hash === null || hash === undefined) {
+    addError(errors, fileLabel, `${hashKey} must be set when ${rootKey} is provided`);
+    return;
+  }
+
+  if (typeof hash !== 'string' || !HEX_32_REGEX.test(hash)) {
+    addError(errors, fileLabel, `${hashKey} must be a 32-byte hex string`);
+    return;
+  }
+
+  const expectedHash = namehash(root.trim());
+  if (!equalsIgnoreCase(expectedHash, hash)) {
+    addError(
+      errors,
+      fileLabel,
+      `${hashKey} does not match namehash(${root.trim()}), expected ${expectedHash}`
+    );
+  }
+}
+
+function validateEnsConfig(errors, fileLabel, data, { variant }) {
+  if (!data || typeof data !== 'object') {
+    addError(errors, fileLabel, 'configuration must be an object');
+    return;
+  }
+
+  const registry = data.registry;
+  if (registry === null || registry === undefined) {
+    addError(errors, fileLabel, 'registry must be specified');
+  } else if (variant === 'mainnet') {
+    validateAddress(errors, fileLabel, registry, { field: 'registry' });
+    if (typeof registry === 'string' && !equalsIgnoreCase(registry, ENS_MAINNET_REGISTRY)) {
+      addError(errors, fileLabel, `registry must equal ${ENS_MAINNET_REGISTRY} on mainnet`);
+    }
+  } else if (registry !== ZERO_ADDRESS) {
+    validateAddress(errors, fileLabel, registry, { field: 'registry', allowZero: false });
+  }
+
+  validateEnsRoot(errors, fileLabel, data, 'agentRoot', 'agentRootHash', {
+    required: variant === 'mainnet',
+  });
+  validateEnsRoot(errors, fileLabel, data, 'clubRoot', 'clubRootHash', {
+    required: variant === 'mainnet',
+  });
+}
+
+function validateParamsConfig(errors, fileLabel, data) {
+  if (!data || typeof data !== 'object') {
+    addError(errors, fileLabel, 'configuration must be an object');
+    return;
+  }
+
+  ensureInteger(errors, fileLabel, data, 'commitWindow', { positive: true });
+  ensureInteger(errors, fileLabel, data, 'revealWindow', { positive: true });
+  ensureInteger(errors, fileLabel, data, 'disputeWindow', { positive: true });
+
+  const approval = ensureInteger(errors, fileLabel, data, 'approvalThresholdBps', {
+    min: 0,
+    max: 10_000,
+  });
+  const fee = ensureInteger(errors, fileLabel, data, 'feeBps', { min: 0, max: 10_000 });
+  const slash = ensureInteger(errors, fileLabel, data, 'slashBpsMax', { min: 0, max: 10_000 });
+  const quorumMin = ensureInteger(errors, fileLabel, data, 'quorumMin', { min: 1 });
+  const quorumMax = ensureInteger(errors, fileLabel, data, 'quorumMax', { min: 1 });
+
+  if (quorumMin !== null && quorumMax !== null && quorumMax < quorumMin) {
+    addError(errors, fileLabel, 'quorumMax must be greater than or equal to quorumMin');
+  }
+
+  if (approval !== null && slash !== null && approval > slash) {
+    // approval threshold does not need to be less than slash, but catch extreme misconfiguration
+    if (slash < 100) {
+      addError(errors, fileLabel, 'slashBpsMax is unexpectedly lower than approvalThresholdBps');
+    }
+  }
+
+  if (fee !== null && slash !== null && fee > slash) {
+    addError(errors, fileLabel, 'slashBpsMax must be at least as large as feeBps');
+  }
+}
+
+function validateAllConfigs({ baseDir } = {}) {
+  const configDir = baseDir || path.join(__dirname, '..', 'config');
+  const errors = [];
+
+  const files = [
+    {
+      name: 'agialpha.dev.json',
+      validator: (data) => validateAgiAlphaConfig(errors, 'agialpha.dev.json', data, { variant: 'dev' }),
+    },
+    {
+      name: 'agialpha.mainnet.json',
+      validator: (data) =>
+        validateAgiAlphaConfig(errors, 'agialpha.mainnet.json', data, { variant: 'mainnet' }),
+    },
+    {
+      name: 'ens.dev.json',
+      validator: (data) => validateEnsConfig(errors, 'ens.dev.json', data, { variant: 'dev' }),
+    },
+    {
+      name: 'ens.mainnet.json',
+      validator: (data) => validateEnsConfig(errors, 'ens.mainnet.json', data, { variant: 'mainnet' }),
+    },
+    {
+      name: 'params.json',
+      validator: (data) => validateParamsConfig(errors, 'params.json', data),
+    },
+  ];
+
+  for (const entry of files) {
+    const filePath = path.join(configDir, entry.name);
+    try {
+      const data = readJson(filePath);
+      entry.validator(data);
+    } catch (error) {
+      addError(errors, entry.name, error.message);
+    }
+  }
+
+  return { errors };
+}
+
+function main() {
+  const { errors } = validateAllConfigs();
+  if (errors.length > 0) {
+    console.error('Configuration validation failed:');
+    for (const message of errors) {
+      console.error(` - ${message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('All configuration files passed validation.');
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  validateAllConfigs,
+  _internal: {
+    readJson,
+    validateAgiAlphaConfig,
+    validateEnsConfig,
+    validateParamsConfig,
+    validateEnsRoot,
+    ensureInteger,
+    validateAddress,
+  },
+};

--- a/test/configValidation.test.js
+++ b/test/configValidation.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { validateAllConfigs } = require('../scripts/validate-config');
+
+contract('Configuration validation', () => {
+  it('passes with repository configuration set', function () {
+    const { errors } = validateAllConfigs();
+    assert.deepEqual(errors, []);
+  });
+
+  it('detects invalid entries in mutated configuration payloads', function () {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agijobs-config-'));
+    const configDir = path.join(__dirname, '..', 'config');
+    fs.cpSync(configDir, tmpDir, { recursive: true });
+
+    try {
+      const agiMainnetPath = path.join(tmpDir, 'agialpha.mainnet.json');
+      const agiMainnet = JSON.parse(fs.readFileSync(agiMainnetPath, 'utf8'));
+      agiMainnet.token = '0x0000000000000000000000000000000000000000';
+      fs.writeFileSync(agiMainnetPath, JSON.stringify(agiMainnet, null, 2));
+
+      const ensMainnetPath = path.join(tmpDir, 'ens.mainnet.json');
+      const ensMainnet = JSON.parse(fs.readFileSync(ensMainnetPath, 'utf8'));
+      ensMainnet.agentRootHash = '0x1234';
+      fs.writeFileSync(ensMainnetPath, JSON.stringify(ensMainnet, null, 2));
+
+      const paramsPath = path.join(tmpDir, 'params.json');
+      const params = JSON.parse(fs.readFileSync(paramsPath, 'utf8'));
+      params.quorumMax = 1;
+      params.quorumMin = 5;
+      fs.writeFileSync(paramsPath, JSON.stringify(params, null, 2));
+
+      const { errors } = validateAllConfigs({ baseDir: tmpDir });
+      assert.isAbove(errors.length, 0, 'expected validation errors');
+      assert.isTrue(
+        errors.some((message) => message.includes('agialpha.mainnet.json')),
+        'should flag token address override'
+      );
+      assert.isTrue(
+        errors.some((message) => message.includes('ens.mainnet.json')),
+        'should flag ENS hash mismatch'
+      );
+      assert.isTrue(
+        errors.some((message) => message.includes('params.json')),
+        'should flag quorum ordering issue'
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a configuration validator that checks AGIALPHA token, ENS namehashes, and governance thresholds
- add mocha coverage for the validator and expose an npm script to run it
- document the config validation command in the README quickstart and configuration guidance

## Testing
- npm run test
- npm run config:validate

------
https://chatgpt.com/codex/tasks/task_e_68cf18139ad88333aa8c5bd8fa16bb54