### PR TITLE
Add dedicated Sepolia configuration profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,18 @@ cp .env.example .env
 
 Edit configuration files under `config/` to match the deployment environment:
 
-- `config/agialpha.dev.json` / `config/agialpha.mainnet.json` — ERC-20 token parameters and burn address. The development
-  variant ships with a `mock` stake token marker that triggers a mock deployment during migrations.
-- `config/ens.dev.json` / `config/ens.mainnet.json` — ENS registry and subdomain roots (refresh namehashes with either
+- `config/agialpha.dev.json` / `config/agialpha.sepolia.json` / `config/agialpha.mainnet.json` — ERC-20 token parameters and
+  burn address. The development variant ships with a `mock` stake token marker that triggers a mock deployment during
+  migrations, while the dedicated Sepolia profile prevents local development runs from overwriting testnet addresses.
+- `config/ens.dev.json` / `config/ens.sepolia.json` / `config/ens.mainnet.json` — ENS registry and subdomain roots (refresh
   `npm run namehash -- <variant>` or `node scripts/compute-namehash.js <path-to-config>`; the variant command defaults to
   `mainnet`).
 - `config/params.json` — Commit/reveal/dispute windows and governance thresholds.
 - Run `npm run config:validate` after editing to confirm addresses, namehashes, and governance parameters satisfy production
   guardrails before broadcasting migrations.
+
+Sepolia deployments now read from their own configuration files, so populate `config/agialpha.sepolia.json` and
+`config/ens.sepolia.json` with the staging token and ENS registry addresses before migrating to that network.
 
 ### Manual verification: ENS namehash script
 

--- a/config/agialpha.sepolia.json
+++ b/config/agialpha.sepolia.json
@@ -1,0 +1,5 @@
+{
+  "token": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
+  "decimals": 18,
+  "burnAddress": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000"
+}

--- a/config/ens.sepolia.json
+++ b/config/ens.sepolia.json
@@ -1,0 +1,7 @@
+{
+  "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+  "agentRoot": "agent.agi.eth",
+  "clubRoot": "club.agi.eth",
+  "agentRootHash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
+  "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16"
+}

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -3,6 +3,8 @@ const path = require('path');
 
 const DEFAULT_VARIANT = 'mainnet';
 
+const DEV_VARIANTS = new Set(['dev', 'development', 'localhost', 'hardhat']);
+
 function resolveVariant(networkOrVariant = DEFAULT_VARIANT) {
   if (!networkOrVariant) {
     return DEFAULT_VARIANT;
@@ -14,15 +16,11 @@ function resolveVariant(networkOrVariant = DEFAULT_VARIANT) {
     return 'mainnet';
   }
 
-  const devVariants = new Set([
-    'dev',
-    'development',
-    'localhost',
-    'hardhat',
-    'sepolia'
-  ]);
+  if (normalized === 'sepolia') {
+    return 'sepolia';
+  }
 
-  if (devVariants.has(normalized)) {
+  if (DEV_VARIANTS.has(normalized)) {
     return 'dev';
   }
 


### PR DESCRIPTION
## Summary
- add Sepolia-specific AGIALPHA and ENS configuration files so staging deployments no longer inherit mutated development values
- teach the config loader and validator about the new Sepolia variant and document the workflow update in the README

## Testing
- npm run config:validate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf1b12dc808333801394637faa93b6