### PR TITLE
Enforce explicit network variants across config tooling

### DIFF
--- a/scripts/compute-namehash.js
+++ b/scripts/compute-namehash.js
@@ -42,14 +42,19 @@ const { network, explicitPath } = parseArguments(process.argv);
 let targetPath;
 let config;
 
-if (explicitPath) {
-  targetPath = path.resolve(process.cwd(), explicitPath);
-  const raw = fs.readFileSync(targetPath, 'utf8');
-  config = JSON.parse(raw);
-} else {
-  const variant = resolveVariant(network);
-  targetPath = configPath('ens', variant);
-  config = readConfig('ens', variant);
+try {
+  if (explicitPath) {
+    targetPath = path.resolve(process.cwd(), explicitPath);
+    const raw = fs.readFileSync(targetPath, 'utf8');
+    config = JSON.parse(raw);
+  } else {
+    const variant = resolveVariant(network);
+    targetPath = configPath('ens', variant);
+    config = readConfig('ens', variant);
+  }
+} catch (error) {
+  console.error(error.message || error);
+  process.exit(1);
 }
 
 const assignHash = (rootKey, hashKey) => {

--- a/scripts/config-loader.js
+++ b/scripts/config-loader.js
@@ -3,7 +3,20 @@ const path = require('path');
 
 const DEFAULT_VARIANT = 'mainnet';
 
-const DEV_VARIANTS = new Set(['dev', 'development', 'localhost', 'hardhat']);
+const VARIANT_ALIASES = new Map(
+  Object.entries({
+    mainnet: 'mainnet',
+    sepolia: 'sepolia',
+    dev: 'dev',
+    development: 'dev',
+    localhost: 'dev',
+    hardhat: 'dev',
+    test: 'dev',
+    coverage: 'dev',
+  })
+);
+
+const SUPPORTED_VARIANTS = ['mainnet', 'sepolia', 'dev'];
 
 function resolveVariant(networkOrVariant = DEFAULT_VARIANT) {
   if (!networkOrVariant) {
@@ -12,19 +25,16 @@ function resolveVariant(networkOrVariant = DEFAULT_VARIANT) {
 
   const normalized = networkOrVariant.toLowerCase();
 
-  if (normalized === 'mainnet') {
-    return 'mainnet';
+  const resolved = VARIANT_ALIASES.get(normalized);
+  if (resolved) {
+    return resolved;
   }
 
-  if (normalized === 'sepolia') {
-    return 'sepolia';
-  }
-
-  if (DEV_VARIANTS.has(normalized)) {
-    return 'dev';
-  }
-
-  return DEFAULT_VARIANT;
+  throw new Error(
+    `Unsupported network variant "${networkOrVariant}". Expected one of: ${SUPPORTED_VARIANTS.join(
+      ', '
+    )}`
+  );
 }
 
 function configPath(configName, networkOrVariant) {
@@ -41,5 +51,6 @@ function readConfig(configName, networkOrVariant) {
 module.exports = {
   configPath,
   readConfig,
-  resolveVariant
+  resolveVariant,
+  SUPPORTED_VARIANTS,
 };

--- a/scripts/seed-ens-dev.js
+++ b/scripts/seed-ens-dev.js
@@ -21,7 +21,15 @@ const labelhash = (label) => {
 module.exports = async function (callback) {
   try {
     const networkName = extractNetwork(process.argv) || process.env.TRUFFLE_NETWORK;
-    const variant = resolveVariant(networkName);
+    let variant;
+    try {
+      variant = resolveVariant(networkName);
+    } catch (error) {
+      console.error(error.message || error);
+      process.exitCode = 1;
+      callback(error);
+      return;
+    }
 
     if (variant !== 'dev') {
       console.log('Skipping ENS seeding for non-development network');

--- a/test/configValidation.test.js
+++ b/test/configValidation.test.js
@@ -3,6 +3,7 @@ const os = require('os');
 const path = require('path');
 
 const { validateAllConfigs } = require('../scripts/validate-config');
+const { resolveVariant } = require('../scripts/config-loader');
 
 contract('Configuration validation', () => {
   it('passes with repository configuration set', function () {
@@ -49,5 +50,23 @@ contract('Configuration validation', () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+contract('Config loader variant resolution', () => {
+  it('normalizes development aliases to dev', function () {
+    ['dev', 'development', 'localhost', 'hardhat', 'test', 'coverage'].forEach((alias) => {
+      assert.strictEqual(resolveVariant(alias), 'dev');
+    });
+  });
+
+  it('recognizes explicit mainnet and sepolia variants', function () {
+    assert.strictEqual(resolveVariant('mainnet'), 'mainnet');
+    assert.strictEqual(resolveVariant('sepolia'), 'sepolia');
+  });
+
+  it('throws for unsupported variants to avoid silent fallbacks', function () {
+    assert.throws(() => resolveVariant('staging'), /Unsupported network variant/);
+    assert.throws(() => resolveVariant('prod'), /Unsupported network variant/);
   });
 });


### PR DESCRIPTION
## Summary
- enforce explicit network variant resolution and throw when an unknown name is supplied
- harden namehash and ENS seeding scripts to surface resolution errors cleanly
- add regression tests covering the new resolveVariant behaviour and accepted aliases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf20684d28833383b7357d529fbb2c