### PR TITLE
feat: harden flatten workflow for production verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Generate single-file Solidity sources for third-party verifiers with the helper 
 ./scripts/flatten.sh
 ```
 
-The script writes flattened sources to `artifacts-public/flat/`, reusing the repository's local `truffle-flattener` installation. If the script is unavailable in your shell, fall back to the underlying command:
+The script writes flattened sources to `artifacts-public/flat/`, mirroring the contract subdirectories (for example `core/StakeManager.flat.sol`) and skipping library/test harness directories so the output focuses on deployable entrypoints. It reuses the repository's local `truffle-flattener` installation. If the script is unavailable in your shell, fall back to the underlying command:
 
 ```bash
 npx truffle-flattener <path-to-contract> > artifacts-public/flat/<Contract>.flat.sol

--- a/scripts/flatten.sh
+++ b/scripts/flatten.sh
@@ -6,8 +6,16 @@ CONTRACTS_DIR="contracts"
 
 mkdir -p "${OUTPUT_DIR}"
 
-shopt -s nullglob
-contracts=("${CONTRACTS_DIR}"/*.sol)
+if ! command -v find >/dev/null 2>&1; then
+  echo "Error: 'find' command not available in PATH." >&2
+  exit 1
+fi
+
+mapfile -t contracts < <(
+  find "${CONTRACTS_DIR}" -type f -name '*.sol' \
+    ! -path "${CONTRACTS_DIR}/core/testing/*" \
+    ! -path "${CONTRACTS_DIR}/libs/*"
+)
 
 if [ ${#contracts[@]} -eq 0 ]; then
   echo "No Solidity contracts found in ${CONTRACTS_DIR}."
@@ -15,9 +23,28 @@ if [ ${#contracts[@]} -eq 0 ]; then
 fi
 
 for contract in "${contracts[@]}"; do
-  filename=$(basename "${contract}")
+  rel_path="${contract#${CONTRACTS_DIR}/}"
+
+  # Skip migration artifacts that do not require verification.
+  if [[ "${rel_path}" == "Migrations.sol" ]]; then
+    continue
+  fi
+
+  relative_dir="$(dirname "${rel_path}")"
+  if [[ "${relative_dir}" == "." ]]; then
+    target_dir="${OUTPUT_DIR}"
+  else
+    target_dir="${OUTPUT_DIR}/${relative_dir}"
+  fi
+  mkdir -p "${target_dir}"
+
+  filename="$(basename "${rel_path}")"
   flat_name="${filename%.sol}.flat.sol"
-  echo "Flattening ${contract} -> ${OUTPUT_DIR}/${flat_name}"
-  npx --yes truffle-flattener "${contract}" > "${OUTPUT_DIR}/${flat_name}"
+  target_path="${target_dir}/${flat_name}"
+
+  echo "Flattening ${contract} -> ${target_path}"
+  npx --yes truffle-flattener "${contract}" > "${target_path}"
 done
+
+echo "Flattened ${#contracts[@]} contract(s) into ${OUTPUT_DIR}."
 

--- a/test/flattenScript.test.js
+++ b/test/flattenScript.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+contract('Flatten script automation', () => {
+  it('flattens core contracts into structured outputs', function () {
+    this.timeout(300000);
+
+    const flatDir = path.join(__dirname, '..', 'artifacts-public', 'flat');
+    if (fs.existsSync(flatDir)) {
+      fs.rmSync(flatDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(flatDir, { recursive: true });
+
+    execFileSync('bash', ['scripts/flatten.sh'], { stdio: 'inherit' });
+
+    const stakeManagerFlat = path.join(flatDir, 'core', 'StakeManager.flat.sol');
+    assert.isTrue(fs.existsSync(stakeManagerFlat), 'StakeManager flat artifact missing');
+    const content = fs.readFileSync(stakeManagerFlat, 'utf8');
+    assert.match(
+      content,
+      /contract\s+StakeManager/,
+      'flattened StakeManager should contain contract source'
+    );
+
+    const libsDir = path.join(flatDir, 'libs');
+    assert.isFalse(fs.existsSync(libsDir), 'library directories should be skipped');
+  });
+});


### PR DESCRIPTION
## Summary
- expand scripts/flatten.sh to recursively flatten deployable contracts into a mirrored directory structure while skipping libraries and tests
- document the updated behaviour in the README so production operators know where flattened artifacts are written
- add an automated test that runs the flatten script and asserts core outputs exist without leaking library folders

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf271e48e483338e0896adb769efbd