### PR TITLE
Add registrar verification guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ The script defaults to the local development network. Override it by setting `NE
 NETWORK=sepolia npm run wire:verify
 ```
 
+### Verify registrar pricing
+
+Confirm the `ForeverSubdomainRegistrar` wiring uses the production `$AGIALPHA` token for both agent and club subdomains and enforces the required alpha tier price floor:
+
+```bash
+npm run registrar:verify
+```
+
+The verifier reads `config/registrar.<variant>.json` and checks that every configured ENS root is active on the registrar, has a live pricer, and quotes the expected ERC-20 payment token. When `minPrice` thresholds are defined for specific labels (for example `alpha.club.agi.eth` requiring 5,000 `$AGIALPHA`), the command fails if the registrar returns a lower amount. Use `NETWORK=mainnet npm run registrar:verify` to audit the production deployment prior to go-live.
+
 ### GitHub Actions secrets
 
 Deployments from CI require the following repository secrets so migrations can transfer ownership correctly:

--- a/config/registrar.dev.json
+++ b/config/registrar.dev.json
@@ -1,0 +1,5 @@
+{
+  "address": null,
+  "defaultToken": null,
+  "domains": []
+}

--- a/config/registrar.mainnet.json
+++ b/config/registrar.mainnet.json
@@ -1,0 +1,25 @@
+{
+  "address": "0xD75459a31c389f3EBa9ad9bA778e9Ea574A7a777",
+  "defaultToken": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
+  "domains": [
+    {
+      "name": "agent.agi.eth",
+      "rootKey": "agentRootHash",
+      "labels": [
+        {
+          "label": "builder"
+        }
+      ]
+    },
+    {
+      "name": "club.agi.eth",
+      "rootKey": "clubRootHash",
+      "labels": [
+        {
+          "label": "alpha",
+          "minPrice": "5000000000000000000000"
+        }
+      ]
+    }
+  ]
+}

--- a/config/registrar.sepolia.json
+++ b/config/registrar.sepolia.json
@@ -1,0 +1,5 @@
+{
+  "address": null,
+  "defaultToken": "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
+  "domains": []
+}

--- a/contracts/testing/MockSubdomainRegistrar.sol
+++ b/contracts/testing/MockSubdomainRegistrar.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+contract MockSubdomainPricer {
+    address public token;
+    uint256 public quotedPrice;
+    bool public shouldRevert;
+
+    constructor(address token_, uint256 price_) {
+        token = token_;
+        quotedPrice = price_;
+    }
+
+    function setToken(address token_) external {
+        token = token_;
+    }
+
+    function setPrice(uint256 price_) external {
+        quotedPrice = price_;
+    }
+
+    function setShouldRevert(bool value) external {
+        shouldRevert = value;
+    }
+
+    function price(bytes32, string calldata, uint256) external view returns (address, uint256) {
+        require(!shouldRevert, "Pricer: revert requested");
+        return (token, quotedPrice);
+    }
+}
+
+contract MockForeverSubdomainRegistrar {
+    struct Name {
+        address pricer;
+        address beneficiary;
+        bool active;
+    }
+
+    mapping(bytes32 => Name) public names;
+
+    event DomainConfigured(bytes32 indexed node, address pricer, address beneficiary, bool active);
+
+    function setName(bytes32 node, address pricer, address beneficiary, bool active) external {
+        names[node] = Name({pricer: pricer, beneficiary: beneficiary, active: active});
+        emit DomainConfigured(node, pricer, beneficiary, active);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "export:abis": "node scripts/export-abis.js",
     "export:artifacts": "NETWORK=${NETWORK:-development} node scripts/export-artifacts-runner.js",
     "wire:verify": "npx truffle exec scripts/verify-wiring.js --network ${NETWORK:-development}",
+    "registrar:verify": "npx truffle exec scripts/verify-registrar.js --network ${NETWORK:-development}",
     "namehash": "node scripts/compute-namehash.js",
     "namehash:dev": "node scripts/compute-namehash.js dev",
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",

--- a/scripts/verify-registrar.js
+++ b/scripts/verify-registrar.js
@@ -1,0 +1,281 @@
+const { readConfig, resolveVariant } = require('./config-loader');
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const DEFAULT_DURATION = 31_536_000; // 365 days
+
+const REGISTRAR_ABI = [
+  {
+    constant: true,
+    inputs: [{ name: '', type: 'bytes32' }],
+    name: 'names',
+    outputs: [
+      { name: 'pricer', type: 'address' },
+      { name: 'beneficiary', type: 'address' },
+      { name: 'active', type: 'bool' },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+const PRICER_ABI = [
+  {
+    constant: true,
+    inputs: [
+      { name: 'parentNode', type: 'bytes32' },
+      { name: 'label', type: 'string' },
+      { name: 'duration', type: 'uint256' },
+    ],
+    name: 'price',
+    outputs: [
+      { name: 'token', type: 'address' },
+      { name: 'price', type: 'uint256' },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+function extractNetwork(argv) {
+  const networkFlagIndex = argv.findIndex((arg) => arg === '--network');
+  if (networkFlagIndex !== -1 && argv[networkFlagIndex + 1]) {
+    return argv[networkFlagIndex + 1];
+  }
+
+  return undefined;
+}
+
+function normalizeHex(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed.toLowerCase();
+}
+
+function normalizeLabel(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+function toBigInt(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'bigint') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      throw new Error(`Expected integer but received ${value}`);
+    }
+    return BigInt(value);
+  }
+  if (typeof value === 'string') {
+    if (!/^\d+$/.test(value)) {
+      throw new Error(`Expected decimal string but received "${value}"`);
+    }
+    return BigInt(value);
+  }
+  throw new Error(`Unsupported numeric type ${typeof value}`);
+}
+
+function resolveNode(domainConfig, ensConfig) {
+  if (domainConfig.node) {
+    return normalizeHex(domainConfig.node);
+  }
+  if (domainConfig.rootKey) {
+    const key = domainConfig.rootKey;
+    const value = ensConfig ? ensConfig[key] : undefined;
+    if (typeof value === 'string') {
+      return normalizeHex(value);
+    }
+  }
+  return null;
+}
+
+async function ensurePrice({
+  web3,
+  pricerAddress,
+  parentNode,
+  label,
+  expectedToken,
+  minPrice,
+  maxPrice,
+  duration,
+}) {
+  const pricer = new web3.eth.Contract(PRICER_ABI, pricerAddress);
+  try {
+    const result = await pricer.methods.price(parentNode, label, duration.toString()).call();
+    const token = normalizeHex(result.token);
+    const price = BigInt(result.price);
+
+    if (expectedToken && token !== expectedToken) {
+      throw new Error(
+        `Price check token mismatch for label "${label}" on ${parentNode}: expected ${expectedToken} but got ${token}`
+      );
+    }
+
+    if (minPrice !== null && price < minPrice) {
+      throw new Error(
+        `Price for label "${label}" on ${parentNode} is below minimum (${price.toString()} < ${minPrice.toString()})`
+      );
+    }
+
+    if (maxPrice !== null && price > maxPrice) {
+      throw new Error(
+        `Price for label "${label}" on ${parentNode} exceeds maximum (${price.toString()} > ${maxPrice.toString()})`
+      );
+    }
+
+    return { token, price };
+  } catch (error) {
+    if (error && error.message) {
+      throw new Error(`Failed to query price for label "${label}" on ${parentNode}: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+async function verifyDomain({ web3, registrar, domainConfig, ensConfig, defaultToken, logger }) {
+  const node = resolveNode(domainConfig, ensConfig);
+  if (!node) {
+    throw new Error(`Domain entry ${domainConfig.name || 'unknown'} is missing a resolvable node hash`);
+  }
+
+  const info = await registrar.methods.names(node).call();
+  const pricerAddress = normalizeHex(info.pricer);
+  const beneficiary = normalizeHex(info.beneficiary);
+  const active = Boolean(info.active);
+
+  if (!active) {
+    throw new Error(`Domain ${domainConfig.name || node} is not active on registrar`);
+  }
+
+  if (!pricerAddress || pricerAddress === ZERO_ADDRESS) {
+    throw new Error(`Domain ${domainConfig.name || node} is missing an assigned pricer`);
+  }
+
+  if (domainConfig.expectedBeneficiary) {
+    const expected = normalizeHex(domainConfig.expectedBeneficiary);
+    if (!expected) {
+      throw new Error(`expectedBeneficiary for ${domainConfig.name || node} is not a valid address`);
+    }
+    if (beneficiary !== expected) {
+      throw new Error(
+        `Beneficiary mismatch for ${domainConfig.name || node}: expected ${expected} but found ${beneficiary}`
+      );
+    }
+  }
+
+  const labels = Array.isArray(domainConfig.labels) ? domainConfig.labels : [];
+  const domainLabel = domainConfig.name || node;
+  const results = [];
+
+  if (labels.length === 0 && logger) {
+    logger.log(`Domain ${domainLabel} active with pricer ${pricerAddress}; no label checks configured.`);
+  }
+
+  for (const entry of labels) {
+    const label = normalizeLabel(entry.label);
+    if (!label) {
+      throw new Error(`Label entry for domain ${domainLabel} is missing a valid label string`);
+    }
+
+    const expectedToken = normalizeHex(entry.expectedToken || domainConfig.expectedToken || defaultToken);
+    const minPrice = entry.minPrice !== undefined && entry.minPrice !== null ? toBigInt(entry.minPrice) : null;
+    const maxPrice = entry.maxPrice !== undefined && entry.maxPrice !== null ? toBigInt(entry.maxPrice) : null;
+    const durationSource =
+      entry.duration !== undefined && entry.duration !== null
+        ? entry.duration
+        : domainConfig.defaultDuration !== undefined
+        ? domainConfig.defaultDuration
+        : DEFAULT_DURATION;
+    const duration = toBigInt(durationSource);
+
+    const { token, price } = await ensurePrice({
+      web3,
+      pricerAddress,
+      parentNode: node,
+      label,
+      expectedToken,
+      minPrice,
+      maxPrice,
+      duration,
+    });
+
+    if (logger) {
+      const descriptor = [`token ${token || 'unknown'}`, `price ${price.toString()}`];
+      logger.log(`Domain ${domainLabel} label "${label}" verified (${descriptor.join(', ')})`);
+    }
+
+    results.push({ label, token, price, duration });
+  }
+
+  return { node, pricer: pricerAddress, beneficiary, labels: results };
+}
+
+async function verifyRegistrar({ web3, network, config, ensConfig, logger = console }) {
+  if (!config || typeof config !== 'object') {
+    throw new Error('Registrar configuration must be an object');
+  }
+
+  const address = normalizeHex(config.address);
+  if (!address || address === ZERO_ADDRESS) {
+    if (logger) {
+      logger.log('Registrar address is not configured for this network; skipping verification.');
+    }
+    return { skipped: true };
+  }
+
+  const registrar = new web3.eth.Contract(REGISTRAR_ABI, address);
+  const defaultToken = normalizeHex(config.defaultToken);
+  const domains = Array.isArray(config.domains) ? config.domains : [];
+
+  if (domains.length === 0 && logger) {
+    logger.log('No registrar domains configured; nothing to verify.');
+  }
+
+  const results = [];
+  for (const domain of domains) {
+    const outcome = await verifyDomain({ web3, registrar, domainConfig: domain, ensConfig, defaultToken, logger });
+    results.push(outcome);
+  }
+
+  if (logger) {
+    logger.log(`Registrar ${address} verification complete (${results.length} domain checks).`);
+  }
+
+  return { skipped: false, results };
+}
+
+module.exports = async function (callback) {
+  try {
+    const networkName = extractNetwork(process.argv) || process.env.NETWORK || process.env.TRUFFLE_NETWORK;
+    const variant = resolveVariant(networkName);
+    const registrarConfig = readConfig('registrar', variant);
+    const ensConfig = readConfig('ens', variant);
+    await verifyRegistrar({ web3, network: variant, config: registrarConfig, ensConfig, logger: console });
+    callback();
+  } catch (error) {
+    console.error(error.message || error);
+    process.exitCode = 1;
+    callback(error);
+  }
+};
+
+module.exports.verifyRegistrar = verifyRegistrar;
+module.exports._internal = {
+  extractNetwork,
+  normalizeHex,
+  normalizeLabel,
+  resolveNode,
+  toBigInt,
+  ensurePrice,
+  verifyDomain,
+};

--- a/test/configValidation.test.js
+++ b/test/configValidation.test.js
@@ -35,6 +35,13 @@ contract('Configuration validation', () => {
       params.quorumMin = 5;
       fs.writeFileSync(paramsPath, JSON.stringify(params, null, 2));
 
+      const registrarMainnetPath = path.join(tmpDir, 'registrar.mainnet.json');
+      const registrarMainnet = JSON.parse(fs.readFileSync(registrarMainnetPath, 'utf8'));
+      registrarMainnet.address = '0x0000000000000000000000000000000000000000';
+      registrarMainnet.domains[0].labels[0].minPrice = '-1';
+      registrarMainnet.domains[0].labels[0].label = '';
+      fs.writeFileSync(registrarMainnetPath, JSON.stringify(registrarMainnet, null, 2));
+
       const { errors } = validateAllConfigs({ baseDir: tmpDir });
       assert.isAbove(errors.length, 0, 'expected validation errors');
       assert.isTrue(
@@ -56,6 +63,10 @@ contract('Configuration validation', () => {
       assert.isTrue(
         errors.some((message) => message.includes('params.json')),
         'should flag quorum ordering issue'
+      );
+      assert.isTrue(
+        errors.some((message) => message.includes('registrar.mainnet.json')),
+        'should flag registrar misconfiguration'
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/registrarVerifier.test.js
+++ b/test/registrarVerifier.test.js
@@ -1,0 +1,113 @@
+const { verifyRegistrar } = require('../scripts/verify-registrar.js');
+
+const MockForeverSubdomainRegistrar = artifacts.require('MockForeverSubdomainRegistrar');
+const MockSubdomainPricer = artifacts.require('MockSubdomainPricer');
+
+contract('Registrar verification script', (accounts) => {
+  const [deployer, treasury] = accounts;
+  const AGIALPHA = '0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA'.toLowerCase();
+
+  beforeEach(async function () {
+    this.registrar = await MockForeverSubdomainRegistrar.new({ from: deployer });
+    this.pricer = await MockSubdomainPricer.new(AGIALPHA, web3.utils.toWei('5000'), { from: deployer });
+    this.node = web3.utils.randomHex(32);
+    await this.registrar.setName(this.node, this.pricer.address, treasury, true, { from: deployer });
+  });
+
+  function baseConfig(registrarAddress, node) {
+    return {
+      address: registrarAddress,
+      defaultToken: AGIALPHA,
+      domains: [
+        {
+          name: 'club.agi.eth',
+          node,
+          labels: [
+            {
+              label: 'alpha',
+              minPrice: web3.utils.toWei('5000'),
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it('verifies active registrar domains and price metadata', async function () {
+    const config = baseConfig(this.registrar.address, this.node);
+    const result = await verifyRegistrar({
+      web3,
+      network: 'development',
+      config,
+      ensConfig: {},
+      logger: { log() {} },
+    });
+    assert.isFalse(result.skipped);
+    assert.strictEqual(result.results.length, 1);
+    assert.strictEqual(result.results[0].labels.length, 1);
+    assert.strictEqual(result.results[0].labels[0].token, AGIALPHA);
+  });
+
+  it('throws when registrar domain is inactive', async function () {
+    await this.registrar.setName(this.node, this.pricer.address, treasury, false, { from: deployer });
+    const config = baseConfig(this.registrar.address, this.node);
+    try {
+      await verifyRegistrar({ web3, network: 'development', config, ensConfig: {}, logger: { log() {} } });
+      assert.fail('expected inactive registrar domain to fail verification');
+    } catch (error) {
+      assert.include(String(error.message || error), 'not active', 'should surface inactivity');
+    }
+  });
+
+  it('throws when price token mismatches expected configuration', async function () {
+    await this.pricer.setToken(accounts[9], { from: deployer });
+    const config = baseConfig(this.registrar.address, this.node);
+    try {
+      await verifyRegistrar({ web3, network: 'development', config, ensConfig: {}, logger: { log() {} } });
+      assert.fail('expected token mismatch to fail verification');
+    } catch (error) {
+      assert.include(String(error.message || error), 'token mismatch', 'should report token mismatch');
+    }
+  });
+
+  it('supports resolving nodes from ENS configuration root keys', async function () {
+    const config = {
+      address: this.registrar.address,
+      defaultToken: AGIALPHA,
+      domains: [
+        {
+          name: 'club.agi.eth',
+          rootKey: 'clubRootHash',
+          labels: [
+            {
+              label: 'alpha',
+            },
+          ],
+        },
+      ],
+    };
+
+    const ensConfig = { clubRootHash: this.node };
+    const result = await verifyRegistrar({
+      web3,
+      network: 'development',
+      config,
+      ensConfig,
+      logger: { log() {} },
+    });
+
+    assert.strictEqual(result.results[0].labels[0].token, AGIALPHA);
+  });
+
+  it('skips verification when registrar address is unset', async function () {
+    const config = { address: null, domains: [] };
+    const result = await verifyRegistrar({
+      web3,
+      network: 'development',
+      config,
+      ensConfig: {},
+      logger: { log() {} },
+    });
+    assert.isTrue(result.skipped);
+  });
+});


### PR DESCRIPTION
## Summary
- add production registrar configuration profiles and mainnet pricing guardrails for alpha club domains
- introduce a Truffle exec script that verifies registrar wiring and price/token expectations against ENS roots
- extend configuration validation and test suite with registrar checks and supporting mock contracts

## Testing
- npm run lint:sol
- npm test
- npm run config:validate
- npm run registrar:verify


------
https://chatgpt.com/codex/tasks/task_e_68cf3057851483338a3c89f4d702d651