### PR TITLE
chore: align ens ownership pragmas with toolchain

### DIFF
--- a/contracts/core/IdentityRegistry.sol
+++ b/contracts/core/IdentityRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {Ownable} from "../libs/Ownable.sol";
 

--- a/contracts/libs/EnsOwnership.sol
+++ b/contracts/libs/EnsOwnership.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IENSRegistryLike {
+    function owner(bytes32 node) external view returns (address);
+}
+
+library EnsOwnership {
+    error EnsOwnershipRegistryUnset();
+
+    function owner(address registry, bytes32 node) internal view returns (address) {
+        if (registry == address(0)) {
+            revert EnsOwnershipRegistryUnset();
+        }
+        return IENSRegistryLike(registry).owner(node);
+    }
+
+    function isOwner(address registry, bytes32 node, address account) internal view returns (bool) {
+        if (account == address(0)) {
+            return false;
+        }
+        return owner(registry, node) == account;
+    }
+
+    function deriveNode(bytes32 root, bytes32[] memory labels) internal pure returns (bytes32 node) {
+        node = root;
+        for (uint256 i = 0; i < labels.length; i++) {
+            node = keccak256(abi.encodePacked(node, labels[i]));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add the EnsOwnership helper library with a Solidity ^0.8.23 pragma to align with the configured compiler
- bump IdentityRegistry to Solidity ^0.8.23 to match the toolchain configuration

## Testing
- npx hardhat compile

------
https://chatgpt.com/codex/tasks/task_e_68cf3ee73a088333a65f336ad9e73544