### PR TITLE
Handle ENS NameWrapper ownership in IdentityRegistry

### DIFF
--- a/config/ens.dev.json
+++ b/config/ens.dev.json
@@ -1,5 +1,6 @@
 {
   "registry": "0x0000000000000000000000000000000000000000",
+  "nameWrapper": null,
   "agentRoot": null,
   "clubRoot": null,
   "agentRootHash": null,

--- a/config/ens.sepolia.json
+++ b/config/ens.sepolia.json
@@ -1,5 +1,6 @@
 {
   "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+  "nameWrapper": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
   "agentRoot": "agent.agi.eth",
   "clubRoot": "club.agi.eth",
   "agentRootHash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",

--- a/contracts/libs/EnsOwnership.sol
+++ b/contracts/libs/EnsOwnership.sol
@@ -5,21 +5,46 @@ interface IENSRegistryLike {
     function owner(bytes32 node) external view returns (address);
 }
 
+interface IENSNameWrapperLike {
+    function ownerOf(uint256 id) external view returns (address);
+
+    function getData(uint256 id) external view returns (address owner, uint32 fuses, uint64 expiry);
+}
+
 library EnsOwnership {
     error EnsOwnershipRegistryUnset();
 
-    function owner(address registry, bytes32 node) internal view returns (address) {
+    function owner(address registry, address wrapper, bytes32 node) internal view returns (address) {
         if (registry == address(0)) {
             revert EnsOwnershipRegistryUnset();
         }
-        return IENSRegistryLike(registry).owner(node);
+
+        address currentOwner = IENSRegistryLike(registry).owner(node);
+        if (currentOwner != wrapper || wrapper == address(0)) {
+            return currentOwner;
+        }
+
+        uint256 tokenId = uint256(node);
+        try IENSNameWrapperLike(wrapper).ownerOf(tokenId) returns (address wrappedOwner) {
+            if (wrappedOwner != address(0)) {
+                return wrappedOwner;
+            }
+        } catch {}
+
+        try IENSNameWrapperLike(wrapper).getData(tokenId) returns (address wrappedOwner, uint32, uint64) {
+            if (wrappedOwner != address(0)) {
+                return wrappedOwner;
+            }
+        } catch {}
+
+        return currentOwner;
     }
 
-    function isOwner(address registry, bytes32 node, address account) internal view returns (bool) {
+    function isOwner(address registry, address wrapper, bytes32 node, address account) internal view returns (bool) {
         if (account == address(0)) {
             return false;
         }
-        return owner(registry, node) == account;
+        return owner(registry, wrapper, node) == account;
     }
 
     function deriveNode(bytes32 root, bytes32[] memory labels) internal pure returns (bytes32 node) {

--- a/contracts/libs/EnsOwnership.sol
+++ b/contracts/libs/EnsOwnership.sol
@@ -69,9 +69,14 @@ library EnsOwnership {
 
     function _wrappedOwnerViaGetData(address wrapper, uint256 tokenId) private view returns (address) {
         try IENSNameWrapperLike(wrapper).getData(tokenId) returns (address wrappedOwner, uint32 fuses, uint64 expiry) {
-            // Silence warnings about unused tuple components while ensuring compatibility with the interface.
-            fuses;
-            expiry;
+            if (wrappedOwner == address(0) && fuses == 0 && expiry == 0) {
+                return address(0);
+            }
+
+            if (expiry != 0 && expiry < block.timestamp) {
+                return address(0);
+            }
+
             return wrappedOwner;
         } catch {
             return address(0);

--- a/contracts/libs/MockENSNameWrapper.sol
+++ b/contracts/libs/MockENSNameWrapper.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+/// @dev Minimal ENS NameWrapper mock that allows toggling the ownerOf behaviour.
+contract MockENSNameWrapper {
+    error OwnerOfDisabled();
+
+    mapping(uint256 => address) private _owners;
+    bool private _ownerOfEnabled = true;
+
+    function setWrappedOwner(bytes32 node, address owner) external {
+        _owners[uint256(node)] = owner;
+    }
+
+    function setOwnerOfEnabled(bool enabled) external {
+        _ownerOfEnabled = enabled;
+    }
+
+    function ownerOf(uint256 id) external view returns (address) {
+        if (!_ownerOfEnabled) {
+            revert OwnerOfDisabled();
+        }
+        return _owners[id];
+    }
+
+    function getData(uint256 id) external view returns (address owner, uint32 fuses, uint64 expiry) {
+        owner = _owners[id];
+        fuses = 0;
+        expiry = 0;
+    }
+}

--- a/contracts/libs/MockENSNameWrapper.sol
+++ b/contracts/libs/MockENSNameWrapper.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {IENSNameWrapperLike} from "./EnsOwnership.sol";
+
 /// @dev Minimal ENS NameWrapper mock that allows toggling the ownerOf behaviour.
-contract MockENSNameWrapper {
+contract MockENSNameWrapper is IENSNameWrapperLike {
     error OwnerOfDisabled();
 
     mapping(uint256 => address) private _owners;
@@ -16,14 +18,14 @@ contract MockENSNameWrapper {
         _ownerOfEnabled = enabled;
     }
 
-    function ownerOf(uint256 id) external view returns (address) {
+    function ownerOf(uint256 id) external view override returns (address) {
         if (!_ownerOfEnabled) {
             revert OwnerOfDisabled();
         }
         return _owners[id];
     }
 
-    function getData(uint256 id) external view returns (address owner, uint32 fuses, uint64 expiry) {
+    function getData(uint256 id) external view override returns (address owner, uint32 fuses, uint64 expiry) {
         owner = _owners[id];
         fuses = 0;
         expiry = 0;

--- a/contracts/libs/MockENSRegistry.sol
+++ b/contracts/libs/MockENSRegistry.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
+
+import {IENSRegistryLike} from "./EnsOwnership.sol";
 
 /// @dev Lightweight ENS registry used for tests that require ownership tracking.
-contract MockENSRegistry {
+contract MockENSRegistry is IENSRegistryLike {
     event Transfer(bytes32 indexed node, address owner);
     event NewOwner(bytes32 indexed node, bytes32 indexed label, address owner);
 
@@ -16,7 +18,7 @@ contract MockENSRegistry {
     /// @notice Returns the current owner for a node hash.
     /// @param node Hash identifying the ENS node.
     /// @return Address that controls the specified node.
-    function owner(bytes32 node) external view returns (address) {
+    function owner(bytes32 node) external view override returns (address) {
         return _owners[node];
     }
 

--- a/migrations/4_configure_ens_and_params.js
+++ b/migrations/4_configure_ens_and_params.js
@@ -5,6 +5,6 @@ module.exports = async function (_deployer, network, _accounts) {
   const ensCfg = readConfig('ens', network);
   const identity = await IdentityRegistry.deployed();
   if (ensCfg.agentRootHash && ensCfg.clubRootHash) {
-    await identity.configureMainnet(ensCfg.registry, ensCfg.agentRootHash, ensCfg.clubRootHash);
+    await identity.configureMainnet(ensCfg.registry, ensCfg.nameWrapper, ensCfg.agentRootHash, ensCfg.clubRootHash);
   }
 };


### PR DESCRIPTION
## Summary
- extend the ENS ownership helper to resolve wrapped owners through the NameWrapper
- store and expose the NameWrapper address from IdentityRegistry and update configuration handling
- update configuration, migrations, and tests to cover wrapped ENS ownership

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf4e1e17cc833393dae8954a827f4b