### PR TITLE
Add wiring verification to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - run: npm run lint:sol
       - run: npm run test
       - run: npm run coverage
+      - name: Verify contract wiring
+        run: |
+          NETWORK=development npm run wire:verify
       - name: Upload coverage to Codecov
         if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7


### PR DESCRIPTION
## Summary
- add a CI step to run the wiring verification script against the development network

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf58dd18408333a0f59ad28a3fc875