### PR TITLE
feat: extend ENS configuration with alpha support

### DIFF
--- a/config/ens.dev.json
+++ b/config/ens.dev.json
@@ -4,5 +4,8 @@
   "agentRoot": null,
   "clubRoot": null,
   "agentRootHash": null,
-  "clubRootHash": null
+  "clubRootHash": null,
+  "alphaClubRoot": null,
+  "alphaClubRootHash": null,
+  "alphaEnabled": false
 }

--- a/config/ens.mainnet.json
+++ b/config/ens.mainnet.json
@@ -4,5 +4,8 @@
   "agentRoot": "agent.agi.eth",
   "clubRoot": "club.agi.eth",
   "agentRootHash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
-  "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16"
+  "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+  "alphaClubRoot": "alpha.club.agi.eth",
+  "alphaClubRootHash": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e",
+  "alphaEnabled": false
 }

--- a/config/ens.sepolia.json
+++ b/config/ens.sepolia.json
@@ -4,5 +4,8 @@
   "agentRoot": "agent.agi.eth",
   "clubRoot": "club.agi.eth",
   "agentRootHash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
-  "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16"
+  "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+  "alphaClubRoot": "alpha.club.agi.eth",
+  "alphaClubRootHash": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e",
+  "alphaEnabled": false
 }

--- a/contracts/core/IdentityRegistry.sol
+++ b/contracts/core/IdentityRegistry.sol
@@ -7,18 +7,26 @@ import {Ownable} from "../libs/Ownable.sol";
 /// @title IdentityRegistry
 /// @notice Maintains ENS related configuration and an emergency allow list.
 contract IdentityRegistry is Ownable {
-    event EnsConfigured(address indexed registry, address indexed wrapper, bytes32 agentRootHash, bytes32 clubRootHash);
+    event EnsConfigured(
+        address indexed registry,
+        address indexed wrapper,
+        bytes32 agentRootHash,
+        bytes32 clubRootHash,
+        bytes32 alphaClubRootHash,
+        bool alphaEnabled
+    );
     event EmergencyAccessUpdated(address indexed account, bool allowed);
 
     address public ensRegistry;
     address public ensNameWrapper;
     bytes32 public agentRootHash;
     bytes32 public clubRootHash;
+    bytes32 public alphaClubRootHash;
+    bool public alphaEnabled;
 
     mapping(address => bool) private _emergencyAllowList;
 
     string private constant _ENS_UNCONFIGURED = "IdentityRegistry: ENS";
-    string private constant _WRAPPER_UNCONFIGURED = "IdentityRegistry: ENS wrapper";
     string private constant _AGENT_ROOT_UNCONFIGURED = "IdentityRegistry: agent root";
     string private constant _CLUB_ROOT_UNCONFIGURED = "IdentityRegistry: club root";
 
@@ -27,19 +35,28 @@ contract IdentityRegistry is Ownable {
     /// @param wrapper Address of the ENS NameWrapper responsible for wrapped ownership.
     /// @param agentHash Node hash representing the authorized agent subdomain.
     /// @param clubHash Node hash representing the authorized club subdomain.
-    function configureMainnet(address registry, address wrapper, bytes32 agentHash, bytes32 clubHash)
-        external
-        onlyOwner
-    {
+    /// @param alphaClubHash Optional node hash for the alpha.club.agi.eth root.
+    /// @param alphaClubEnabled Boolean flag to allow alpha root based identities.
+    function configureEns(
+        address registry,
+        address wrapper,
+        bytes32 agentHash,
+        bytes32 clubHash,
+        bytes32 alphaClubHash,
+        bool alphaClubEnabled
+    ) external onlyOwner {
         require(registry != address(0), "IdentityRegistry: registry");
-        require(wrapper != address(0), "IdentityRegistry: wrapper");
         require(agentHash != bytes32(0), "IdentityRegistry: agent hash");
         require(clubHash != bytes32(0), "IdentityRegistry: club hash");
+
         ensRegistry = registry;
         ensNameWrapper = wrapper;
         agentRootHash = agentHash;
         clubRootHash = clubHash;
-        emit EnsConfigured(registry, wrapper, agentHash, clubHash);
+        alphaClubRootHash = alphaClubHash;
+        alphaEnabled = alphaClubEnabled;
+
+        emit EnsConfigured(registry, wrapper, agentHash, clubHash, alphaClubHash, alphaClubEnabled);
     }
 
     /// @notice Adds or removes an address from the emergency allow list.
@@ -154,6 +171,5 @@ contract IdentityRegistry is Ownable {
 
     function _ensureEnsConfigured() private view {
         require(ensRegistry != address(0), _ENS_UNCONFIGURED);
-        require(ensNameWrapper != address(0), _WRAPPER_UNCONFIGURED);
     }
 }

--- a/migrations/4_configure_ens_and_params.js
+++ b/migrations/4_configure_ens_and_params.js
@@ -5,6 +5,13 @@ module.exports = async function (_deployer, network, _accounts) {
   const ensCfg = readConfig('ens', network);
   const identity = await IdentityRegistry.deployed();
   if (ensCfg.agentRootHash && ensCfg.clubRootHash) {
-    await identity.configureMainnet(ensCfg.registry, ensCfg.nameWrapper, ensCfg.agentRootHash, ensCfg.clubRootHash);
+    await identity.configureEns(
+      ensCfg.registry,
+      ensCfg.nameWrapper,
+      ensCfg.agentRootHash,
+      ensCfg.clubRootHash,
+      ensCfg.alphaClubRootHash || '0x'.padEnd(66, '0'),
+      Boolean(ensCfg.alphaEnabled)
+    );
   }
 };

--- a/scripts/compute-namehash.js
+++ b/scripts/compute-namehash.js
@@ -68,6 +68,7 @@ const assignHash = (rootKey, hashKey) => {
 
 assignHash('agentRoot', 'agentRootHash');
 assignHash('clubRoot', 'clubRootHash');
+assignHash('alphaClubRoot', 'alphaClubRootHash');
 
 fs.writeFileSync(targetPath, `${JSON.stringify(config, null, 2)}\n`);
 console.log(`Updated ENS namehashes in ${targetPath}`);


### PR DESCRIPTION
## Summary
- expand `IdentityRegistry` configuration to track an optional alpha ENS root and allow deployments without a wrapper
- add alpha club metadata across ENS config files, migrations, and the namehash helper script
- harden the wiring verification script with alpha ENS expectations and config/state validation, and refresh tests for the new flow

## Testing
- npm run test
- NETWORK=development npm run wire:verify *(fails: no RPC running)*

------
https://chatgpt.com/codex/tasks/task_e_68cf59aabf888333ade39aa681962410