### PR TITLE
Add fuzzing invariants and document gas workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Verify contract wiring
         run: |
           NETWORK=development npm run wire:verify
+      - name: Verify registrar pricing
+        run: |
+          NETWORK=development npm run registrar:verify
       - name: Upload coverage to Codecov
         if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Local verification artifacts
+gasReporterOutput.json
+gas-report.txt
+echidna-corpus/
+artifacts/echidna-long/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ npm run config:validate
 
 `npm run coverage` enforces a 90% minimum threshold across lines, branches, and functions to match our CI gate. When the CI workflow has access to the repository `CODECOV_TOKEN` secret (for pushes and internal branches), it uploads `coverage/lcov.info` to Codecov so the badge above reflects the latest main-branch run automatically, even for private mirrors; forked pull requests skip the upload without failing the build.
 
+## Advanced validation
+
+- **Property-based fuzzing** — Install [Echidna](https://github.com/crytic/echidna) locally and run `npm run fuzz:echidna` to execute the `EchidnaJobRegistryInvariants` harness with the quick `tools/echidna.yaml` profile. The command reuses the same configuration the CI smoke test runs and writes its corpus to `echidna-corpus/` (ignored from source control). For deeper campaigns, call `npm run fuzz:echidna:long` to switch to the extended `tools/echidna-long.yaml` profile used by the scheduled nightly workflow.
+- **Gas accounting** — `npm run gas` boots a transient Hardhat node, executes the full Truffle suite with `eth-gas-reporter`, and saves both the console-formatted table (`gas-report.txt`) and structured metrics (`gasReporterOutput.json`). Monitor these artifacts in PRs to flag regressions; CI uploads the same files for every run so reviewers can diff them against previous executions.
+
 ## Configure
 
 ```bash

--- a/contracts/core/EchidnaJobRegistryInvariants.sol
+++ b/contracts/core/EchidnaJobRegistryInvariants.sol
@@ -252,6 +252,7 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
                 uint256 currentDeposits = stakeManager.totalDeposits(previousJobWorker);
                 if (previousDeposits > currentDeposits) {
                     uint256 realizedSlash = previousDeposits - currentDeposits;
+                    expectedFees += realizedSlash;
                     if (realizedSlash > maxSlash) {
                         slashBoundsViolated = true;
                     }
@@ -323,6 +324,12 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
     /// @return True when the recorded fees match the expected accumulator.
     function echidna_fee_accounting_consistent() external view returns (bool) {
         return feePool.totalFeesRecorded() == expectedFees;
+    }
+
+    /// @notice Ensures the fee pool holds the exact token balance that has been recorded.
+    /// @return True if the ERC20 balance matches the accounting accumulator.
+    function echidna_fee_pool_balance_matches_recorded() external view returns (bool) {
+        return stakeToken.balanceOf(address(feePool)) == feePool.totalFeesRecorded();
     }
 
     /// @notice Ensures dispute resolutions never slash more than the configured maximum.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "coverage:run": "npx hardhat coverage --testfiles 'test/**/*.js'",
     "coverage:check": "node scripts/check-coverage.js",
     "gas": "TRUFFLE_TEST=true REPORT_GAS=true node scripts/run-tests.js",
+    "fuzz:echidna": "echidna-test ./contracts/core/EchidnaJobRegistryInvariants.sol --contract EchidnaJobRegistryInvariants --config tools/echidna.yaml",
+    "fuzz:echidna:long": "echidna-test ./contracts/core/EchidnaJobRegistryInvariants.sol --contract EchidnaJobRegistryInvariants --config tools/echidna-long.yaml",
     "dev:prep": "npm run namehash:dev && npx truffle exec scripts/seed-ens-dev.js --network development",
     "migrate:dev": "npx truffle migrate --reset --network development",
     "migrate:mainnet": "npx truffle migrate --reset --network mainnet",


### PR DESCRIPTION
## Summary
- extend the Echidna job registry harness to track realized slash fees and assert the fee pool token balance matches recorded totals
- expose npm scripts and README guidance for running Echidna smoke/long campaigns and for harvesting gas metrics locally
- wire registrar verification into CI and ignore local fuzzing/gas artifacts so production-only token enforcement stays gated in automation

## Testing
- npm run lint:sol
- npm run test
- npm run gas

------
https://chatgpt.com/codex/tasks/task_e_68cf71729d9c8333b81960158887763d