### PR TITLE
docs: finalize release guidance for pause rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Edit configuration files under `config/` to match the deployment environment:
 - Run `npm run config:validate` after editing to confirm addresses, namehashes, and governance parameters satisfy production
   guardrails before broadcasting migrations.
 
+### Alpha Club activation
+
+Premium `alpha.club.agi.eth` identities ship pre-configured in `config/ens.*.json`. The registrar enforces the 5,000 `$AGIALPHA`
+price floor automatically, so only funded registrations can mint these labels. Governance controls whether the `IdentityRegistry`
+marks the alpha namespace as officially active via the `alphaEnabled` flag that `configureEns` manages. Keep the flag `false`
+until the Alpha Club launch materials (for example, the dedicated registration flow) are ready, then execute
+`configureEns(alphaClubRootHash, /*alphaEnabled=*/true)` from the Safe to emit the activation event. Because ENS ownership checks
+already cover nested labels, existing alpha subdomains remain valid on-chain even before the flip; the toggle simply signals
+readiness to integrators and monitoring infrastructure.
+
 Sepolia deployments now read from their own configuration files, so populate `config/agialpha.sepolia.json` and
 `config/ens.sepolia.json` with the staging token and ENS registry addresses before migrating to that network.
 
@@ -155,6 +165,16 @@ npm run registrar:verify
 ```
 
 The verifier reads `config/registrar.<variant>.json` and checks that every configured ENS root is active on the registrar, has a live pricer, and quotes the expected ERC-20 payment token. When `minPrice` thresholds are defined for specific labels (for example `alpha.club.agi.eth` requiring 5,000 `$AGIALPHA`), the command fails if the registrar returns a lower amount. Use `NETWORK=mainnet npm run registrar:verify` to audit the production deployment prior to go-live.
+
+## Release checklist
+
+1. Run the full CI matrix locally (`npm run lint`, `npm run test`, `npm run coverage`, `npm run config:validate`) to catch
+   regressions before tagging.
+2. Export refreshed addresses/ABIs with `npm run export:artifacts` and publish them under `artifacts-public/` for integrators.
+3. Bump `package.json` and `CHANGELOG.md` to the next semantic version (for example, `v1.1.0` for the pause feature rollout) and
+   create a signed git tag once CI is green.
+4. Update `docs/mainnet-deployment-simulation.md` with live transaction hashes, Safe execution links, and the final
+   `alphaEnabled` state after the deployment or Alpha Club activation.
 
 ### GitHub Actions secrets
 

--- a/audit/threat-model.md
+++ b/audit/threat-model.md
@@ -21,6 +21,8 @@ This document outlines key assumptions and mitigations for the AGIJobsv1 protoco
 - Emergency allow list limited to explicitly set addresses in `IdentityRegistry`.
 - StakeManager exposes a governance-only emergency release path to unlock stuck worker stake without touching balances.
 - Protocol-wide pause capability halts new lifecycle invocations during incidents while preserving recovery flows through `StakeManager`.
+- Incident runbooks require governance to document the reason for any pause and reference the Safe transactions used so auditors
+  can correlate mitigations with on-chain events.
 - Unit tests cover lifecycle happy paths and dispute resolution bounds.
 - Static analysis (Solhint, Slither) and fuzzing (Echidna smoke) wired via CI.
 

--- a/docs/mainnet-deployment-simulation.md
+++ b/docs/mainnet-deployment-simulation.md
@@ -48,6 +48,13 @@ pre-flight checklist before running against the live network.
    the same console session to confirm every pausable module reports
    `paused() === false` post-migration and rehearse the Safe/timelock steps for
    invoking (and later clearing) a pause if an emergency response is required.
+6. **Alpha Club activation plan.** Decide whether the production launch will
+   flip `alphaEnabled` to `true` via `IdentityRegistry.configureEns`. The
+   configuration JSON already embeds the `alphaClubRootHash`, so the Safe only
+   needs to pass the stored value when calling `configureEns(alphaClubRootHash,
+   true)`. Capture the decision, execution transaction hash, and post-action
+   `alphaEnabled()` result in this log once finalized so downstream integrators
+   know whether premium subdomains are live.
 
 Update this section with transaction hashes, verification links, and console
 outputs once the live deployment completes.
@@ -158,7 +165,11 @@ After ownership transfers to the governance Safe or timelock, run a dedicated pa
    ```
 
 2. **Rehearse the pause.** Stage a Safe (or timelock) transaction bundle targeting each module's `pause()` function. No broadcast is required during the simulation, but capture the calldata and signer thresholds so the incident bridge can execute the sequence without additional prep. Pausing halts new deposits, job lifecycle actions, and dispute callbacks while still allowing `StakeManager.withdraw` (worker initiated) and `StakeManager.emergencyRelease` (owner initiated) to run for controlled exits.
-3. **Document recovery.** Prepare the matching `unpause()` calls plus a checklist to re-run the `paused()` queries above. After an incident is mitigated, execute `unpause()` via the same governance owner and re-verify every module reports `false` before resuming normal operations.
+3. **Record user guidance.** Document the communication plan for alerting
+   workers about withdrawal options and the path for resuming operations once
+   the incident is resolved. Include links to the Safe transactions that toggle
+   pause state so auditors can trace the mitigation timeline.
+4. **Document recovery.** Prepare the matching `unpause()` calls plus a checklist to re-run the `paused()` queries above. After an incident is mitigated, execute `unpause()` via the same governance owner and re-verify every module reports `false` before resuming normal operations.
 
 Store the pause/unpause calldata alongside the deployment package so governance can trigger the response plan immediately if production conditions require it.
 


### PR DESCRIPTION
## Summary
- document how and when to toggle the Alpha Club ENS flag and capture the decision in deployment records
- add a release checklist covering CI, artifacts export, versioning, and simulation log updates
- extend the pause drill and threat model with communication expectations for any emergency toggles

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cffc91781c833396a294560a16eb3c