### PR TITLE
docs: capture alpha activation and pause operations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,3 +16,9 @@ All Solidity smart contracts, deployment scripts, and configuration files within
 4. Release patched versions and document mitigations.
 
 We appreciate responsible disclosure and do not offer bug bounties at this time.
+
+## Operational response expectations
+
+- **Emergency pause.** Only the governance Safe (or configured timelock) can invoke the pausable module guards. When a pause is triggered, capture the Safe execution link, describe the motivating incident, and update `docs/mainnet-deployment-simulation.md` so stakeholders can audit the chronology. Workers retain access to `StakeManager.withdraw` during a pause, and governance can invoke `StakeManager.emergencyRelease` to facilitate controlled exits.
+- **Alpha Club activation.** Flipping `IdentityRegistry.configureEns(..., /*alphaEnabled=*/true)` marks premium `alpha.club.agi.eth` labels as officially supported. Record the transaction hash and resulting registry state in the deployment log immediately so integrators can confirm the tier is live.
+- **Post-incident recovery.** After unpausing or modifying ENS configuration, rerun the wiring checks (`npm run wire:verify`) and export refreshed artifacts with `npm run export:artifacts` to keep public ABIs/addresses in sync with production.

--- a/audit/threat-model.md
+++ b/audit/threat-model.md
@@ -23,6 +23,9 @@ This document outlines key assumptions and mitigations for the AGIJobsv1 protoco
 - Protocol-wide pause capability halts new lifecycle invocations during incidents while preserving recovery flows through `StakeManager`.
 - Incident runbooks require governance to document the reason for any pause and reference the Safe transactions used so auditors
   can correlate mitigations with on-chain events.
+- Alpha Club premium tier remains opt-in until governance flips `alphaEnabled` via `IdentityRegistry.configureEns`. The
+  deployment log (`docs/mainnet-deployment-simulation.md`) must be updated with the activation hash so integrators can confirm
+  when premium identities become part of the supported surface area.
 - Unit tests cover lifecycle happy paths and dispute resolution bounds.
 - Static analysis (Solhint, Slither) and fuzzing (Echidna smoke) wired via CI.
 
@@ -31,3 +34,5 @@ This document outlines key assumptions and mitigations for the AGIJobsv1 protoco
 - Off-chain components (Safe, ENS) must be configured correctly by deployment operators.
 - Governance timelock delay must be calibrated for stakeholder response time.
 - Paused operations require coordinated response to resume activity and complete any queued job settlements.
+- Advertising Alpha Club labels before `alphaEnabled` flips may confuse downstream integrations. Communications must align with
+  the on-chain flag to avoid prematurely onboarding users to an inactive premium tier.

--- a/docs/mainnet-deployment-simulation.md
+++ b/docs/mainnet-deployment-simulation.md
@@ -58,6 +58,32 @@ pre-flight checklist before running against the live network.
 
 Update this section with transaction hashes, verification links, and console
 outputs once the live deployment completes.
+### Production deployment ledger
+
+Populate the tables below with concrete data immediately after the mainnet rollout. They provide the single reference point auditors and downstream integrators will consult for live wiring and administrative actions. Replace the placeholder rows once transactions have been executed.
+
+#### Core contract addresses
+
+| Contract | Address | Deployment transaction hash |
+| -------- | ------- | --------------------------- |
+| IdentityRegistry | `<pending>` | `<tx-hash>` |
+| StakeManager | `<pending>` | `<tx-hash>` |
+| JobRegistry | `<pending>` | `<tx-hash>` |
+| DisputeModule | `<pending>` | `<tx-hash>` |
+| ReputationEngine | `<pending>` | `<tx-hash>` |
+| FeePool | `<pending>` | `<tx-hash>` |
+| ValidationModule | `<pending>` | `<tx-hash>` |
+| CertificateNFT | `<pending>` | `<tx-hash>` |
+
+Copy values directly from `artifacts-public/addresses/mainnet.json` after the live migration and record the corresponding deploy transaction hashes for transparency.
+
+#### Governance and feature toggles
+
+| Timestamp (UTC) | Action | Hash / Safe execution link | Notes |
+| --------------- | ------ | -------------------------- | ----- |
+| `<pending>` | `configureEns(alphaClubRootHash, true)` | `<safe-transaction>` | Flip `alphaEnabled` when the Alpha Club launch is live. |
+| `<pending>` | `pause()` / `unpause()` drill | `<safe-transaction>` | Record rehearsal results or production incident response. |
+
 
 ## 1. Environment preparation
 


### PR DESCRIPTION
## Summary
- expand the Alpha Club activation guidance with pre-launch policy, Safe execution steps, and post-toggle verification commands
- document pause response expectations in the README, SECURITY policy, and threat model so operators log incidents consistently
- add a production deployment ledger template to the simulation log for recording contract addresses, transactions, and alpha/pause actions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cffedde5e08333982762b18a8ab168