### PR TITLE
Ensure alpha activation requires configured root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Alpha ENS configuration now respects the feature flag to prevent accidental registry writes in downstream environments.
 - Expanded deployment and operations docs with the latest pause drill and ENS wiring guidance.
+- Hardened `IdentityRegistry.configureEns` so Alpha Club activation requires a non-zero `alphaClubRootHash`, preventing accidental
+  launches without the premium ENS root configured.
 

--- a/contracts/core/IdentityRegistry.sol
+++ b/contracts/core/IdentityRegistry.sol
@@ -49,6 +49,9 @@ contract IdentityRegistry is Ownable {
         require(registry != address(0), "IdentityRegistry: registry");
         require(agentHash != bytes32(0), "IdentityRegistry: agent hash");
         require(clubHash != bytes32(0), "IdentityRegistry: club hash");
+        if (alphaClubEnabled) {
+            require(alphaClubHash != bytes32(0), "IdentityRegistry: alpha hash");
+        }
 
         ensRegistry = registry;
         ensNameWrapper = wrapper;
@@ -90,7 +93,8 @@ contract IdentityRegistry is Ownable {
     }
 
     /// @notice Computes the ENS node derived from the configured agent root and the provided labels.
-    /// @param labels Sequence of label hashes descending from the agent root (e.g. [`keccak256("alpha")`, `keccak256("member")`]).
+    /// @param labels Sequence of label hashes descending from the agent root (e.g.
+    /// [`keccak256("alpha")`, `keccak256("member")`]).
     /// @return node ENS node hash representing the derived subdomain.
     function resolveAgentNode(bytes32[] calldata labels) external view returns (bytes32 node) {
         _ensureEnsConfigured();

--- a/test/identityRegistry.test.js
+++ b/test/identityRegistry.test.js
@@ -77,6 +77,25 @@ contract('IdentityRegistry', (accounts) => {
     assert.strictEqual(await this.registry.ensNameWrapper(), constants.ZERO_ADDRESS);
   });
 
+  it('requires a non-zero alpha root when enabling the alpha tier', async function () {
+    const agentHash = web3.utils.randomHex(32);
+    const clubHash = web3.utils.randomHex(32);
+    await expectRevert(
+      this.registry.configureEns(
+        stranger,
+        worker,
+        agentHash,
+        clubHash,
+        '0x'.padEnd(66, '0'),
+        true,
+        {
+          from: owner,
+        }
+      ),
+      'IdentityRegistry: alpha hash'
+    );
+  });
+
   it('manages emergency allow list and queries', async function () {
     await this.registry.setEmergencyAccess(emergency, true, { from: owner });
     assert.isTrue(await this.registry.hasEmergencyAccess(emergency));


### PR DESCRIPTION
## Summary
- enforce that enabling the Alpha Club ENS tier requires a configured alpha root hash
- cover the new guard with an identity registry unit test and document the hardening in the changelog

## Testing
- `npm run test`
- `npm run lint:sol`
- `npm run config:validate`


------
https://chatgpt.com/codex/tasks/task_e_68d052650cf483338f98c77d1c4dd5bc