### PR TITLE
feat: add job registry configurator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Edit configuration files under `config/` to match the deployment environment:
 - Run `npm run config:validate` after editing to confirm addresses, namehashes, and governance parameters satisfy production
   guardrails before broadcasting migrations.
 
+### JobRegistry configuration helper
+
+- Execute `npm run configure:registry` for a non-destructive dry run that compares the on-chain JobRegistry wiring, lifecycle
+  timings, and governance thresholds against the repository defaults. The summary highlights any drift and prints the sender,
+  owner, and params profile so operators can confirm the context before acting.
+- Pass `-- --execute --from 0xYourOwnerAddress` to broadcast updates from an authorized account. The helper automatically
+  repopulates missing module addresses from local deployments, applies overrides provided via CLI flags (for example,
+  `--modules.identity` or `--thresholds.feeBps`), and validates all numerical constraints before submitting transactions.
+- Override the default configuration profile with `-- --params /path/to/params.json` when staging alternate environments, or
+  use `-- --variant sepolia` to label the summary with the intended target network.
+
 ### Alpha Club activation
 
 Premium `alpha.club.agi.eth` identities ship pre-configured in `config/ens.*.json`. The registrar enforces the 5,000 `$AGIALPHA` price floor automatically, so only funded registrations can mint these labels. `config/registrar.mainnet.json` now fixes both the minimum and maximum `alpha` label price at exactly 5,000 tokens, and `npm run registrar:verify` fails if the deployed `ForeverSubdomainRegistrar` drifts above that ceiling. Governance controls whether the `IdentityRegistry` marks the alpha namespace as officially active via the `alphaEnabled` flag that `configureEns` manages.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "export:artifacts": "NETWORK=${NETWORK:-development} node scripts/export-artifacts-runner.js",
     "wire:verify": "npx truffle exec scripts/verify-wiring.js --network ${NETWORK:-development}",
     "registrar:verify": "npx truffle exec scripts/verify-registrar.js --network ${NETWORK:-development}",
+    "configure:registry": "npx truffle exec scripts/configure-job-registry.js --network ${NETWORK:-development}",
     "namehash": "node scripts/compute-namehash.js",
     "namehash:dev": "node scripts/compute-namehash.js dev",
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",

--- a/scripts/configure-job-registry.js
+++ b/scripts/configure-job-registry.js
@@ -1,0 +1,346 @@
+const fs = require('fs');
+const path = require('path');
+
+const JobRegistry = artifacts.require('JobRegistry');
+const IdentityRegistry = artifacts.require('IdentityRegistry');
+const StakeManager = artifacts.require('StakeManager');
+const ValidationModule = artifacts.require('ValidationModule');
+const DisputeModule = artifacts.require('DisputeModule');
+const ReputationEngine = artifacts.require('ReputationEngine');
+const FeePool = artifacts.require('FeePool');
+
+const {
+  parseConfiguratorArgs,
+  computeModulesPlan,
+  computeTimingsPlan,
+  computeThresholdsPlan,
+  MODULE_KEYS,
+  TIMING_KEYS,
+  THRESHOLD_KEYS,
+} = require('./lib/job-registry-configurator');
+const { resolveVariant } = require('./config-loader');
+
+const MODULE_ARTIFACTS = {
+  identity: IdentityRegistry,
+  staking: StakeManager,
+  validation: ValidationModule,
+  dispute: DisputeModule,
+  reputation: ReputationEngine,
+  feePool: FeePool,
+};
+
+function extractNetwork(argv) {
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (typeof arg !== 'string' || !arg.startsWith('--')) {
+      continue;
+    }
+
+    const trimmed = arg.slice(2);
+    if (trimmed === 'network') {
+      const next = argv[i + 1];
+      if (next && typeof next === 'string' && !next.startsWith('--')) {
+        return next;
+      }
+    } else if (trimmed.startsWith('network=')) {
+      return trimmed.slice('network='.length);
+    }
+  }
+
+  return undefined;
+}
+
+function loadParamsConfig(paramsPath) {
+  const resolvedPath = paramsPath
+    ? path.resolve(paramsPath)
+    : path.join(__dirname, '..', 'config', 'params.json');
+
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  return { path: resolvedPath, values: parsed };
+}
+
+function toChecksum(address) {
+  if (!address) {
+    return null;
+  }
+
+  try {
+    return web3.utils.toChecksumAddress(address);
+  } catch (error) {
+    return address;
+  }
+}
+
+function formatAddress(address) {
+  const checksum = toChecksum(address);
+  return checksum ? checksum : '(unset)';
+}
+
+function formatDiffEntry(previous, next, formatter = (value) => value) {
+  const prevFormatted =
+    previous === null || previous === undefined ? '(unset)' : formatter(previous);
+  const nextFormatted = formatter(next);
+  return `${prevFormatted} -> ${nextFormatted}`;
+}
+
+async function resolveModuleDefaults(overrides) {
+  const defaults = {};
+
+  for (const key of MODULE_KEYS) {
+    if (overrides[key] !== undefined && overrides[key] !== null) {
+      continue;
+    }
+
+    const artifact = MODULE_ARTIFACTS[key];
+    if (!artifact) {
+      continue;
+    }
+
+    try {
+      const instance = await artifact.deployed();
+      defaults[key] = instance.address;
+    } catch (error) {
+      throw new Error(
+        `Unable to determine default deployment for modules.${key}. Provide an explicit override with --modules.${key}.`
+      );
+    }
+  }
+
+  return defaults;
+}
+
+function normalizeModuleStruct(struct) {
+  const normalized = {};
+  MODULE_KEYS.forEach((key, index) => {
+    let value = struct[key];
+    if (value === undefined) {
+      value = struct[index];
+    }
+    if (value === undefined || value === null || value === '') {
+      normalized[key] = null;
+    } else {
+      normalized[key] = String(value);
+    }
+  });
+  return normalized;
+}
+
+function normalizeNumericStruct(struct, keys) {
+  const normalized = {};
+  keys.forEach((key, index) => {
+    let value = struct[key];
+    if (value === undefined) {
+      value = struct[index];
+    }
+
+    if (value === undefined || value === null) {
+      normalized[key] = null;
+      return;
+    }
+
+    if (typeof value === 'number') {
+      normalized[key] = value;
+      return;
+    }
+
+    if (typeof value.toNumber === 'function') {
+      normalized[key] = value.toNumber();
+      return;
+    }
+
+    if (typeof value.toString === 'function') {
+      normalized[key] = Number(value.toString());
+      return;
+    }
+
+    normalized[key] = Number(value);
+  });
+  return normalized;
+}
+
+function printSectionDiff(label, diff, formatter) {
+  const entries = Object.entries(diff);
+  if (entries.length === 0) {
+    console.log(`- ${label}: no changes required.`);
+    return;
+  }
+
+  console.log(`- ${label}:`);
+  entries.forEach(([key, { previous, next }]) => {
+    console.log(`    ${key}: ${formatDiffEntry(previous, next, formatter)}`);
+  });
+}
+
+function printHelp() {
+  console.log(
+    `Usage: npx truffle exec scripts/configure-job-registry.js --network <network> [options]\n`
+  );
+  console.log('Options:');
+  console.log('  --execute                     Send transactions instead of performing a dry run');
+  console.log('  --dry-run=false               Alias for --execute');
+  console.log('  --from <address>              Sender address for execution');
+  console.log(
+    '  --params <path>               Override params JSON path (defaults to config/params.json)'
+  );
+  console.log(
+    '  --modules.<key> <address>     Override module address (identity, staking, validation, dispute, reputation, feePool)'
+  );
+  console.log(
+    '  --timings.<key> <seconds>     Override lifecycle timing (commitWindow, revealWindow, disputeWindow)'
+  );
+  console.log(
+    '  --thresholds.<key> <value>    Override economic threshold (approvalThresholdBps, quorumMin, quorumMax, feeBps, slashBpsMax)'
+  );
+  console.log('  --variant <name>              Explicit config variant hint for logging');
+  console.log('  --help                        Show this help message');
+}
+
+module.exports = async function (callback) {
+  try {
+    const parsedArgs = parseConfiguratorArgs(process.argv);
+    if (parsedArgs.help) {
+      printHelp();
+      callback();
+      return;
+    }
+
+    const networkName =
+      extractNetwork(process.argv) || process.env.NETWORK || process.env.TRUFFLE_NETWORK || null;
+
+    let resolvedVariant = null;
+    if (parsedArgs.variant || networkName) {
+      try {
+        resolvedVariant = resolveVariant(parsedArgs.variant || networkName);
+      } catch (error) {
+        console.warn(
+          `Warning: unable to resolve variant for "${parsedArgs.variant || networkName}": ${error.message}`
+        );
+      }
+    }
+
+    const paramsConfig = loadParamsConfig(parsedArgs.paramsPath);
+
+    const jobRegistry = await JobRegistry.deployed();
+    const jobRegistryAddress = toChecksum(jobRegistry.address);
+    const owner = toChecksum(await jobRegistry.owner());
+
+    const accounts = await web3.eth.getAccounts();
+    const senderOverride = parsedArgs.from || process.env.CONFIGURE_REGISTRY_FROM || null;
+    const sender = senderOverride
+      ? toChecksum(senderOverride)
+      : accounts[0]
+        ? toChecksum(accounts[0])
+        : null;
+
+    if (!sender) {
+      throw new Error(
+        'Unable to determine sender account. Provide --from <address> or set CONFIGURE_REGISTRY_FROM.'
+      );
+    }
+
+    const moduleDefaults = await resolveModuleDefaults(parsedArgs.modules);
+    const currentModules = normalizeModuleStruct(await jobRegistry.modules());
+    const currentTimings = normalizeNumericStruct(await jobRegistry.timings(), TIMING_KEYS);
+    const currentThresholds = normalizeNumericStruct(
+      await jobRegistry.thresholds(),
+      THRESHOLD_KEYS
+    );
+
+    const modulesPlan = computeModulesPlan({
+      current: currentModules,
+      overrides: parsedArgs.modules,
+      defaults: moduleDefaults,
+    });
+
+    const timingsPlan = computeTimingsPlan({
+      current: currentTimings,
+      overrides: parsedArgs.timings,
+      defaults: paramsConfig.values,
+    });
+
+    const thresholdsPlan = computeThresholdsPlan({
+      current: currentThresholds,
+      overrides: parsedArgs.thresholds,
+      defaults: paramsConfig.values,
+    });
+
+    console.log('AGIJobsv1 — JobRegistry configuration planner');
+    console.log(
+      `Network: ${networkName || '(unspecified)'}${resolvedVariant ? ` (variant: ${resolvedVariant})` : ''}`
+    );
+    console.log(`Params file: ${paramsConfig.path}`);
+    console.log(`JobRegistry: ${jobRegistryAddress}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log(`Sender: ${sender}`);
+
+    if (owner && owner.toLowerCase() !== sender.toLowerCase()) {
+      console.warn(
+        `Warning: sender ${sender} is not the JobRegistry owner. Transactions will likely revert unless forwarded through the owner account.`
+      );
+    }
+
+    console.log('\nPlanned updates:');
+    printSectionDiff('Modules', modulesPlan.diff, (value) => formatAddress(value));
+    printSectionDiff('Timings', timingsPlan.diff, (value) => `${value} seconds`);
+    printSectionDiff('Thresholds', thresholdsPlan.diff, (value) => `${value}`);
+
+    const actions = [];
+    if (modulesPlan.changed) {
+      actions.push(async () => {
+        console.log('Executing setModules…');
+        const receipt = await jobRegistry.setModules(modulesPlan.desired, { from: sender });
+        console.log(`  ✓ setModules tx: ${receipt.tx}`);
+      });
+    }
+
+    if (timingsPlan.changed) {
+      actions.push(async () => {
+        console.log('Executing setTimings…');
+        const { commitWindow, revealWindow, disputeWindow } = timingsPlan.desired;
+        const receipt = await jobRegistry.setTimings(commitWindow, revealWindow, disputeWindow, {
+          from: sender,
+        });
+        console.log(`  ✓ setTimings tx: ${receipt.tx}`);
+      });
+    }
+
+    if (thresholdsPlan.changed) {
+      actions.push(async () => {
+        console.log('Executing setThresholds…');
+        const { approvalThresholdBps, quorumMin, quorumMax, feeBps, slashBpsMax } =
+          thresholdsPlan.desired;
+        const receipt = await jobRegistry.setThresholds(
+          approvalThresholdBps,
+          quorumMin,
+          quorumMax,
+          feeBps,
+          slashBpsMax,
+          { from: sender }
+        );
+        console.log(`  ✓ setThresholds tx: ${receipt.tx}`);
+      });
+    }
+
+    if (actions.length === 0) {
+      console.log('\nAll sections already match the desired configuration.');
+      callback();
+      return;
+    }
+
+    if (!parsedArgs.execute) {
+      console.log('\nDry run complete — re-run with --execute to broadcast the above changes.');
+      callback();
+      return;
+    }
+
+    for (const action of actions) {
+      await action();
+    }
+
+    console.log('\nConfiguration updates applied successfully.');
+    callback();
+  } catch (error) {
+    callback(error);
+  }
+};

--- a/scripts/lib/job-registry-configurator.js
+++ b/scripts/lib/job-registry-configurator.js
@@ -1,0 +1,387 @@
+'use strict';
+
+const MODULE_KEYS = Object.freeze([
+  'identity',
+  'staking',
+  'validation',
+  'dispute',
+  'reputation',
+  'feePool',
+]);
+
+const TIMING_KEYS = Object.freeze(['commitWindow', 'revealWindow', 'disputeWindow']);
+
+const THRESHOLD_KEYS = Object.freeze([
+  'approvalThresholdBps',
+  'quorumMin',
+  'quorumMax',
+  'feeBps',
+  'slashBpsMax',
+]);
+
+const BPS_DENOMINATOR = 10_000;
+
+const IGNORED_FLAGS = new Set(['network']);
+
+function cloneKeys(keys) {
+  return keys.reduce((acc, key) => {
+    acc[key] = undefined;
+    return acc;
+  }, {});
+}
+
+function createDefaultArgs() {
+  return {
+    execute: false,
+    dryRun: true,
+    from: null,
+    paramsPath: null,
+    variant: null,
+    help: false,
+    modules: cloneKeys(MODULE_KEYS),
+    timings: cloneKeys(TIMING_KEYS),
+    thresholds: cloneKeys(THRESHOLD_KEYS),
+  };
+}
+
+function parseConfiguratorArgs(argv) {
+  if (!Array.isArray(argv)) {
+    throw new TypeError('argv must be an array');
+  }
+
+  const args = createDefaultArgs();
+
+  for (let i = 2; i < argv.length; i++) {
+    const raw = argv[i];
+    if (typeof raw !== 'string' || !raw.startsWith('--')) {
+      continue;
+    }
+
+    let key;
+    let value;
+    const eqIndex = raw.indexOf('=');
+    if (eqIndex !== -1) {
+      key = raw.slice(2, eqIndex);
+      value = raw.slice(eqIndex + 1);
+    } else {
+      key = raw.slice(2);
+      const peek = argv[i + 1];
+      if (peek && typeof peek === 'string' && !peek.startsWith('--')) {
+        value = peek;
+        i += 1;
+      } else {
+        value = 'true';
+      }
+    }
+
+    if (!key) {
+      continue;
+    }
+
+    if (IGNORED_FLAGS.has(key)) {
+      continue;
+    }
+
+    if (key === 'help' || key === 'h') {
+      args.help = true;
+      continue;
+    }
+
+    if (key === 'execute') {
+      args.execute = parseBooleanFlag(value, true);
+      continue;
+    }
+
+    if (key === 'dry-run') {
+      args.dryRun = parseBooleanFlag(value, true);
+      continue;
+    }
+
+    if (key === 'from') {
+      args.from = value;
+      continue;
+    }
+
+    if (key === 'params') {
+      args.paramsPath = value;
+      continue;
+    }
+
+    if (key === 'variant') {
+      args.variant = value;
+      continue;
+    }
+
+    if (key.startsWith('modules.')) {
+      assignSectionValue(args.modules, MODULE_KEYS, key.slice('modules.'.length), value, 'modules');
+      continue;
+    }
+
+    if (key.startsWith('timings.')) {
+      assignSectionValue(args.timings, TIMING_KEYS, key.slice('timings.'.length), value, 'timings');
+      continue;
+    }
+
+    if (key.startsWith('thresholds.')) {
+      assignSectionValue(
+        args.thresholds,
+        THRESHOLD_KEYS,
+        key.slice('thresholds.'.length),
+        value,
+        'thresholds'
+      );
+      continue;
+    }
+
+    throw new Error(`Unsupported flag --${key}`);
+  }
+
+  if (args.execute) {
+    args.dryRun = false;
+  } else if (!args.dryRun) {
+    args.execute = true;
+  }
+
+  return args;
+}
+
+function assignSectionValue(container, validKeys, key, value, sectionLabel) {
+  if (!validKeys.includes(key)) {
+    throw new Error(`Unknown ${sectionLabel} option "${key}"`);
+  }
+
+  container[key] = value;
+}
+
+function parseBooleanFlag(value, defaultValue) {
+  if (value === undefined || value === null) {
+    return Boolean(defaultValue);
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized.length === 0) {
+    return Boolean(defaultValue);
+  }
+
+  if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  throw new Error(`Unable to parse boolean flag value "${value}"`);
+}
+
+function normalizeAddress(value, label) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be a string`);
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+
+  if (!/^0x[0-9a-fA-F]{40}$/.test(trimmed)) {
+    throw new Error(`${label} must be a valid 20-byte hexadecimal address`);
+  }
+
+  return trimmed.toLowerCase();
+}
+
+function parsePositiveInteger(value, label) {
+  if (value === undefined || value === null) {
+    throw new Error(`${label} is required`);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+      throw new Error(`${label} must be a positive integer`);
+    }
+    return value;
+  }
+
+  const normalized = String(value).trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, label) {
+  if (value === undefined || value === null) {
+    throw new Error(`${label} is required`);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+      throw new Error(`${label} must be a non-negative integer`);
+    }
+    return value;
+  }
+
+  const normalized = String(value).trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+
+  return parsed;
+}
+
+function computeDiff(current, desired, keys) {
+  const diff = {};
+  let changed = false;
+
+  keys.forEach((key) => {
+    const currentValue = current && current[key] !== undefined ? current[key] : null;
+    const desiredValue = desired[key];
+    if (currentValue === null || currentValue === undefined) {
+      if (desiredValue !== null && desiredValue !== undefined) {
+        changed = true;
+        diff[key] = { previous: currentValue, next: desiredValue };
+      }
+      return;
+    }
+
+    if (typeof currentValue === 'string' && typeof desiredValue === 'string') {
+      if (currentValue.toLowerCase() !== desiredValue.toLowerCase()) {
+        changed = true;
+        diff[key] = { previous: currentValue, next: desiredValue };
+      }
+      return;
+    }
+
+    if (Number(currentValue) !== Number(desiredValue)) {
+      changed = true;
+      diff[key] = { previous: Number(currentValue), next: Number(desiredValue) };
+    }
+  });
+
+  return { diff, changed };
+}
+
+function computeModulesPlan({ current = {}, overrides = {}, defaults = {} }) {
+  const desired = {};
+
+  MODULE_KEYS.forEach((key) => {
+    const candidate = overrides[key] ?? defaults[key];
+    const label = `modules.${key}`;
+    const normalized = normalizeAddress(candidate, label);
+    desired[key] = normalized;
+  });
+
+  const preparedCurrent = MODULE_KEYS.reduce((acc, key) => {
+    const value = current[key];
+    if (value === undefined || value === null || value === '') {
+      acc[key] = null;
+    } else {
+      acc[key] = String(value).toLowerCase();
+    }
+    return acc;
+  }, {});
+
+  const { diff, changed } = computeDiff(preparedCurrent, desired, MODULE_KEYS);
+
+  return { desired, diff, changed };
+}
+
+function computeTimingsPlan({ current = {}, overrides = {}, defaults = {} }) {
+  const desired = {};
+
+  TIMING_KEYS.forEach((key) => {
+    const candidate = overrides[key] ?? defaults[key] ?? current[key];
+    desired[key] = parsePositiveInteger(candidate, `timings.${key}`);
+  });
+
+  const normalizedCurrent = TIMING_KEYS.reduce((acc, key) => {
+    if (current[key] === undefined || current[key] === null) {
+      acc[key] = null;
+    } else {
+      acc[key] = Number(current[key]);
+    }
+    return acc;
+  }, {});
+
+  const { diff, changed } = computeDiff(normalizedCurrent, desired, TIMING_KEYS);
+
+  return { desired, diff, changed };
+}
+
+function computeThresholdsPlan({ current = {}, overrides = {}, defaults = {} }) {
+  const desired = {};
+
+  THRESHOLD_KEYS.forEach((key) => {
+    const candidate = overrides[key] ?? defaults[key] ?? current[key];
+    const label = `thresholds.${key}`;
+    if (key === 'approvalThresholdBps' || key === 'feeBps' || key === 'slashBpsMax') {
+      desired[key] = parseBps(candidate, label);
+    } else {
+      desired[key] = parseNonNegativeInteger(candidate, label);
+    }
+  });
+
+  if (desired.quorumMin <= 0) {
+    throw new Error('thresholds.quorumMin must be greater than zero');
+  }
+
+  if (desired.quorumMax < desired.quorumMin) {
+    throw new Error('thresholds.quorumMax must be greater than or equal to thresholds.quorumMin');
+  }
+
+  const normalizedCurrent = THRESHOLD_KEYS.reduce((acc, key) => {
+    if (current[key] === undefined || current[key] === null) {
+      acc[key] = null;
+    } else {
+      acc[key] = Number(current[key]);
+    }
+    return acc;
+  }, {});
+
+  const { diff, changed } = computeDiff(normalizedCurrent, desired, THRESHOLD_KEYS);
+
+  return { desired, diff, changed };
+}
+
+function parseBps(value, label) {
+  const parsed = parseNonNegativeInteger(value, label);
+  if (parsed > BPS_DENOMINATOR) {
+    throw new Error(`${label} must not exceed ${BPS_DENOMINATOR}`);
+  }
+  return parsed;
+}
+
+module.exports = {
+  parseConfiguratorArgs,
+  computeModulesPlan,
+  computeTimingsPlan,
+  computeThresholdsPlan,
+  normalizeAddress,
+  parsePositiveInteger,
+  parseNonNegativeInteger,
+  parseBps,
+  MODULE_KEYS,
+  TIMING_KEYS,
+  THRESHOLD_KEYS,
+  BPS_DENOMINATOR,
+};

--- a/test/jobRegistryConfigurator.test.js
+++ b/test/jobRegistryConfigurator.test.js
@@ -1,0 +1,156 @@
+const { expect } = require('chai');
+
+const {
+  parseConfiguratorArgs,
+  computeModulesPlan,
+  computeTimingsPlan,
+  computeThresholdsPlan,
+  MODULE_KEYS,
+  BPS_DENOMINATOR,
+} = require('../scripts/lib/job-registry-configurator');
+
+function buildAddress(hexDigit) {
+  return `0x${hexDigit.repeat(40)}`;
+}
+
+function fillModules(startDigit) {
+  return MODULE_KEYS.reduce((acc, key, index) => {
+    const digit = ((parseInt(startDigit, 16) + index) % 16).toString(16);
+    acc[key] = buildAddress(digit);
+    return acc;
+  }, {});
+}
+
+describe('job-registry-configurator library', () => {
+  describe('parseConfiguratorArgs', () => {
+    it('parses overrides, booleans, and ignores network flag', () => {
+      const argv = [
+        'node',
+        'script',
+        '--network',
+        'development',
+        '--modules.identity',
+        '0x1234567890abcdef1234567890abcdef12345678',
+        '--timings.commitWindow=7200',
+        '--thresholds.feeBps',
+        '300',
+        '--execute',
+        '--dry-run',
+        'false',
+        '--from',
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      ];
+
+      const parsed = parseConfiguratorArgs(argv);
+      expect(parsed.modules.identity).to.equal('0x1234567890abcdef1234567890abcdef12345678');
+      expect(parsed.timings.commitWindow).to.equal('7200');
+      expect(parsed.thresholds.feeBps).to.equal('300');
+      expect(parsed.execute).to.be.true;
+      expect(parsed.dryRun).to.be.false;
+      expect(parsed.from).to.equal('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+    });
+  });
+
+  describe('computeModulesPlan', () => {
+    it('computes diffs across modules', () => {
+      const current = fillModules('a');
+      const defaults = fillModules('b');
+      const overrides = {
+        identity: '0x1111111111111111111111111111111111111111',
+      };
+
+      const plan = computeModulesPlan({ current, overrides, defaults });
+      expect(plan.changed).to.be.true;
+      expect(Object.keys(plan.diff)).to.include('identity');
+      expect(plan.desired.identity).to.equal('0x1111111111111111111111111111111111111111');
+      expect(plan.desired.staking).to.equal(defaults.staking.toLowerCase());
+    });
+  });
+
+  describe('computeTimingsPlan', () => {
+    it('uses overrides and defaults with validation', () => {
+      const current = { commitWindow: 1000, revealWindow: 1000, disputeWindow: 2000 };
+      const defaults = { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 };
+      const overrides = { revealWindow: '5400' };
+
+      const plan = computeTimingsPlan({ current, overrides, defaults });
+      expect(plan.desired.commitWindow).to.equal(defaults.commitWindow);
+      expect(plan.desired.revealWindow).to.equal(5400);
+      expect(plan.changed).to.be.true;
+      expect(Object.keys(plan.diff)).to.include('revealWindow');
+    });
+  });
+
+  describe('computeThresholdsPlan', () => {
+    it('validates BPS bounds and quorum ordering', () => {
+      const current = {
+        approvalThresholdBps: 5000,
+        quorumMin: 3,
+        quorumMax: 9,
+        feeBps: 150,
+        slashBpsMax: 500,
+      };
+      const defaults = {
+        approvalThresholdBps: BPS_DENOMINATOR,
+        quorumMin: 3,
+        quorumMax: 9,
+        feeBps: 250,
+        slashBpsMax: 1000,
+      };
+      const overrides = {
+        quorumMax: '11',
+        slashBpsMax: String(BPS_DENOMINATOR),
+      };
+
+      const plan = computeThresholdsPlan({ current, overrides, defaults });
+      expect(plan.desired.quorumMax).to.equal(11);
+      expect(plan.desired.slashBpsMax).to.equal(BPS_DENOMINATOR);
+      expect(plan.changed).to.be.true;
+      expect(Object.keys(plan.diff)).to.include('quorumMax');
+    });
+
+    it('rejects invalid quorum relationships', () => {
+      const defaults = {
+        approvalThresholdBps: 6000,
+        quorumMin: 5,
+        quorumMax: 10,
+        feeBps: 200,
+        slashBpsMax: 500,
+      };
+
+      expect(() =>
+        computeThresholdsPlan({
+          current: {},
+          overrides: { quorumMin: '0' },
+          defaults,
+        })
+      ).to.throw('thresholds.quorumMin must be greater than zero');
+
+      expect(() =>
+        computeThresholdsPlan({
+          current: {},
+          overrides: { quorumMin: '6', quorumMax: '5' },
+          defaults,
+        })
+      ).to.throw('thresholds.quorumMax must be greater than or equal to thresholds.quorumMin');
+    });
+
+    it('rejects BPS above denominator', () => {
+      const defaults = {
+        approvalThresholdBps: 6000,
+        quorumMin: 3,
+        quorumMax: 9,
+        feeBps: 250,
+        slashBpsMax: 1000,
+      };
+
+      expect(() =>
+        computeThresholdsPlan({
+          current: {},
+          overrides: { approvalThresholdBps: String(BPS_DENOMINATOR + 1) },
+          defaults,
+        })
+      ).to.throw(`thresholds.approvalThresholdBps must not exceed ${BPS_DENOMINATOR}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a configurable `configure:registry` workflow that wires JobRegistry modules and parameters from CLI or params.json defaults
- provide reusable library helpers plus unit tests for argument parsing and diff planning
- document the new automation entry point for operators in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d17622cc448333888e575055a194e3