### PR TITLE
Add owner-controlled registry migration hooks

### DIFF
--- a/contracts/core/DisputeModule.sol
+++ b/contracts/core/DisputeModule.sol
@@ -21,6 +21,17 @@ contract DisputeModule is Pausable {
         emit JobRegistryUpdated(registry);
     }
 
+    /// @notice Updates the registry authorized to report dispute lifecycle events.
+    /// @param registry Address of the new registry contract.
+    function updateJobRegistry(address registry) external onlyOwner whenPaused {
+        require(registry != address(0), "DisputeModule: registry");
+        address current = jobRegistry;
+        require(current != address(0), "DisputeModule: registry unset");
+        require(current != registry, "DisputeModule: registry unchanged");
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
     modifier onlyRegistry() {
         require(msg.sender == jobRegistry, "DisputeModule: not registry");
         _;

--- a/contracts/core/ReputationEngine.sol
+++ b/contracts/core/ReputationEngine.sol
@@ -21,6 +21,17 @@ contract ReputationEngine is Pausable {
         emit JobRegistryUpdated(registry);
     }
 
+    /// @notice Reassigns the registry controlling reputation adjustments.
+    /// @param registry Address of the replacement registry contract.
+    function updateJobRegistry(address registry) external onlyOwner whenPaused {
+        require(registry != address(0), "ReputationEngine: registry");
+        address current = jobRegistry;
+        require(current != address(0), "ReputationEngine: registry unset");
+        require(current != registry, "ReputationEngine: registry unchanged");
+        jobRegistry = registry;
+        emit JobRegistryUpdated(registry);
+    }
+
     modifier onlyRegistry() {
         require(msg.sender == jobRegistry, "ReputationEngine: not registry");
         _;


### PR DESCRIPTION
## Summary
- allow DisputeModule governance to rotate the authorized JobRegistry behind a pause gate
- add a matching paused migration path for ReputationEngine so reputation accounting stays controllable
- extend Truffle tests to cover the new migration flows and edge-case guards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1805df15c83338dc7be4d9490e723