### PR TITLE
Add JobRegistry owner console CLI with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Edit configuration files under `config/` to match the deployment environment:
 - Override the default configuration profile with `-- --params /path/to/params.json` when staging alternate environments, or
   use `-- --variant sepolia` to label the summary with the intended target network.
 
+### JobRegistry owner console
+
+- Launch the guided owner workflow with `npm run owner:console -- --network <network> status` to inspect configuration or
+  `npm run owner:console -- --network <network> extend --job <id> --commit-extension 3600` to plan actions.
+- The console prints a Safe-ready transaction payload during dry runs so operators can copy/paste it into a multisig. Add
+  `--execute` once satisfied with the plan; the script verifies the sender is the on-chain owner before broadcasting.
+- `extend`, `finalize`, `timeout`, and `resolve` commands enforce the same invariants as the contracts (quorum bounds,
+  slashing ceilings, lifecycle states) so non-technical operators receive human-readable error messages before risking gas.
+
 ### Alpha Club activation
 
 Premium `alpha.club.agi.eth` identities ship pre-configured in `config/ens.*.json`. The registrar enforces the 5,000 `$AGIALPHA` price floor automatically, so only funded registrations can mint these labels. `config/registrar.mainnet.json` now fixes both the minimum and maximum `alpha` label price at exactly 5,000 tokens, and `npm run registrar:verify` fails if the deployed `ForeverSubdomainRegistrar` drifts above that ceiling. Governance controls whether the `IdentityRegistry` marks the alpha namespace as officially active via the `alphaEnabled` flag that `configureEns` manages.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "wire:verify": "npx truffle exec scripts/verify-wiring.js --network ${NETWORK:-development}",
     "registrar:verify": "npx truffle exec scripts/verify-registrar.js --network ${NETWORK:-development}",
     "configure:registry": "npx truffle exec scripts/configure-job-registry.js --network ${NETWORK:-development}",
+    "owner:console": "npx truffle exec scripts/job-registry-owner-console.js --network ${NETWORK:-development}",
     "namehash": "node scripts/compute-namehash.js",
     "namehash:dev": "node scripts/compute-namehash.js dev",
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",

--- a/scripts/job-registry-owner-console.js
+++ b/scripts/job-registry-owner-console.js
@@ -1,0 +1,110 @@
+const JobRegistry = artifacts.require('JobRegistry');
+
+const {
+  parseOwnerConsoleArgs,
+  collectOwnerStatus,
+  buildOwnerTxPlan,
+  formatStatusLines,
+  formatTxPlanLines,
+} = require('./lib/job-registry-owner');
+
+function printHelp() {
+  console.log('AGI Jobs v1 — JobRegistry owner console');
+  console.log(
+    'Usage: npx truffle exec scripts/job-registry-owner-console.js --network <network> [options]'
+  );
+  console.log('');
+  console.log('Positional action (defaults to status):');
+  console.log('  status      Display configuration and optional job summary');
+  console.log("  extend      Extend a job's deadlines");
+  console.log('  finalize    Finalize a revealed job');
+  console.log('  timeout     Timeout a stalled job');
+  console.log('  resolve     Resolve an active dispute');
+  console.log('');
+  console.log('Common options:');
+  console.log('  --help                 Print this message');
+  console.log('  --from <address>       Sender address (defaults to first unlocked account)');
+  console.log('  --execute[=true|false] Broadcast the transaction (defaults to false)');
+  console.log('  --dry-run[=true|false] Alias for --execute');
+  console.log('  --job <id>             Target job identifier (required for actions)');
+  console.log('');
+  console.log('Extend options:');
+  console.log('  --commit-extension <seconds>   Additional commit window seconds');
+  console.log('  --reveal-extension <seconds>   Additional reveal window seconds');
+  console.log('  --dispute-extension <seconds>  Additional dispute window seconds');
+  console.log('');
+  console.log('Finalize options:');
+  console.log('  --success[=true|false]   Whether the job succeeded (default true)');
+  console.log('');
+  console.log('Timeout options:');
+  console.log('  --slash-amount <value>   Slash amount (defaults to 0)');
+  console.log('');
+  console.log('Resolve options:');
+  console.log('  --slash-worker[=true|false]  Slash the worker (default false)');
+  console.log('  --slash-amount <value>       Stake to slash (default 0)');
+  console.log('  --reputation-delta <value>   Signed reputation delta (default 0)');
+}
+
+module.exports = async function (callback) {
+  try {
+    const options = parseOwnerConsoleArgs(process.argv);
+    if (options.help) {
+      printHelp();
+      callback();
+      return;
+    }
+
+    const registry = await JobRegistry.deployed();
+    const owner = await registry.owner();
+    const accounts = await web3.eth.getAccounts();
+    const sender = options.from || accounts[0];
+
+    if (!sender) {
+      throw new Error('No sender account is available. Specify --from explicitly.');
+    }
+
+    const isOwner = sender && owner && sender.toLowerCase() === owner.toLowerCase();
+
+    if (!options.action || options.action === 'status') {
+      const status = await collectOwnerStatus({ registry, web3, owner, jobId: options.jobId });
+      const lines = formatStatusLines(status);
+      lines.forEach((line) => console.log(line));
+      callback();
+      return;
+    }
+
+    const plan = await buildOwnerTxPlan({ registry, web3, options });
+    const callData = registry.contract.methods[plan.method](...plan.args).encodeABI();
+    const lines = formatTxPlanLines(plan, callData, { to: registry.address });
+    lines.forEach((line) => console.log(line));
+
+    if (!options.execute) {
+      console.log('Dry run: transaction not broadcast.');
+      console.log(
+        JSON.stringify(
+          {
+            to: registry.address,
+            from: sender,
+            data: callData,
+            value: '0',
+            description: `JobRegistry.${plan.method}`,
+          },
+          null,
+          2
+        )
+      );
+      callback();
+      return;
+    }
+
+    if (!isOwner) {
+      throw new Error(`Sender ${sender} is not the JobRegistry owner (${owner}).`);
+    }
+
+    const receipt = await registry[plan.method](...plan.args, { from: sender });
+    console.log(`Transaction broadcast. Hash: ${receipt.tx}`);
+    callback();
+  } catch (error) {
+    callback(error);
+  }
+};

--- a/scripts/lib/job-registry-owner.js
+++ b/scripts/lib/job-registry-owner.js
@@ -1,0 +1,552 @@
+'use strict';
+
+const JOB_STATE_NAMES = ['None', 'Created', 'Committed', 'Revealed', 'Finalized', 'Disputed'];
+const BPS_DENOMINATOR = 10000;
+
+function parseBooleanFlag(value, defaultValue) {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 't', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'f', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  throw new Error(`Unable to parse boolean flag from "${value}"`);
+}
+
+function parseOwnerConsoleArgs(argv) {
+  const result = {
+    action: 'status',
+    execute: false,
+    from: null,
+    jobId: null,
+    commitExtension: null,
+    revealExtension: null,
+    disputeExtension: null,
+    success: true,
+    slashWorker: false,
+    slashAmount: '0',
+    reputationDelta: '0',
+    help: false,
+  };
+
+  function assignValue(key, value) {
+    switch (key) {
+      case 'action':
+        if (value) {
+          result.action = String(value);
+        }
+        break;
+      case 'execute': {
+        const boolValue = parseBooleanFlag(value ?? true, true);
+        result.execute = boolValue;
+        break;
+      }
+      case 'dry-run': {
+        const dryRun = parseBooleanFlag(value ?? true, true);
+        result.execute = !dryRun;
+        break;
+      }
+      case 'from':
+        if (value) {
+          result.from = String(value);
+        }
+        break;
+      case 'job':
+      case 'job-id':
+      case 'jobId':
+        if (value !== undefined && value !== null && value !== '') {
+          result.jobId = String(value);
+        }
+        break;
+      case 'commit-extension':
+      case 'commitExtension':
+        result.commitExtension = String(value);
+        break;
+      case 'reveal-extension':
+      case 'revealExtension':
+        result.revealExtension = String(value);
+        break;
+      case 'dispute-extension':
+      case 'disputeExtension':
+        result.disputeExtension = String(value);
+        break;
+      case 'success':
+        result.success = parseBooleanFlag(value ?? true, true);
+        break;
+      case 'slash-worker':
+      case 'slashWorker':
+        result.slashWorker = parseBooleanFlag(value ?? true, true);
+        break;
+      case 'slash-amount':
+      case 'slashAmount':
+        if (value === undefined || value === null) {
+          result.slashAmount = '0';
+        } else {
+          result.slashAmount = String(value);
+        }
+        break;
+      case 'reputation-delta':
+      case 'reputationDelta':
+        if (value === undefined || value === null) {
+          result.reputationDelta = '0';
+        } else {
+          result.reputationDelta = String(value);
+        }
+        break;
+      case 'help':
+        result.help = true;
+        break;
+      default:
+        break;
+    }
+  }
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (typeof arg !== 'string') {
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      const trimmed = arg.slice(2);
+      if (trimmed.includes('=')) {
+        const [key, rawValue] = trimmed.split(/=(.+)/);
+        assignValue(key, rawValue);
+      } else if (trimmed === 'help') {
+        assignValue('help');
+      } else {
+        const key = trimmed;
+        const next = argv[i + 1];
+        if (next === undefined || (typeof next === 'string' && next.startsWith('--'))) {
+          assignValue(key, true);
+        } else {
+          assignValue(key, next);
+          i += 1;
+        }
+      }
+      continue;
+    }
+
+    if (!result.action || result.action === 'status') {
+      result.action = String(arg);
+    }
+  }
+
+  return result;
+}
+
+function jobStateName(stateIndex) {
+  return JOB_STATE_NAMES[stateIndex] || `Unknown(${stateIndex})`;
+}
+
+function formatBigNumber(value) {
+  if (!value) {
+    return '0';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value.toString) {
+    return value.toString();
+  }
+
+  return String(value);
+}
+
+function normalizeStruct(struct, keys) {
+  const normalized = {};
+  keys.forEach((key) => {
+    const value = struct[key];
+    normalized[key] = formatBigNumber(value);
+  });
+  return normalized;
+}
+
+async function collectOwnerStatus({ registry, web3, owner, jobId }) {
+  const [modules, timings, thresholds, config] = await Promise.all([
+    registry.modules(),
+    registry.timings(),
+    registry.thresholds(),
+    registry.configurationStatus(),
+  ]);
+
+  const modulesSummary = normalizeStruct(modules, [
+    'identity',
+    'staking',
+    'validation',
+    'dispute',
+    'reputation',
+    'feePool',
+  ]);
+  const timingsSummary = normalizeStruct(timings, [
+    'commitWindow',
+    'revealWindow',
+    'disputeWindow',
+  ]);
+  const thresholdsSummary = normalizeStruct(thresholds, [
+    'approvalThresholdBps',
+    'quorumMin',
+    'quorumMax',
+    'feeBps',
+    'slashBpsMax',
+  ]);
+
+  const configuration = {
+    modules: Boolean(config[0]),
+    timings: Boolean(config[1]),
+    thresholds: Boolean(config[2]),
+  };
+
+  let jobSummary = null;
+  if (jobId !== null && jobId !== undefined) {
+    const { BN } = web3.utils;
+    const jobIdBn = new BN(jobId);
+    const job = await registry.jobs(jobIdBn);
+    const stateIndex = job.state.toNumber();
+    if (stateIndex !== 0 || job.client !== '0x0000000000000000000000000000000000000000') {
+      jobSummary = {
+        id: jobIdBn.toString(),
+        client: job.client,
+        worker: job.worker,
+        stakeAmount: formatBigNumber(job.stakeAmount),
+        commitDeadline: formatBigNumber(job.commitDeadline),
+        revealDeadline: formatBigNumber(job.revealDeadline),
+        disputeDeadline: formatBigNumber(job.disputeDeadline),
+        commitHash: job.commitHash,
+        state: {
+          value: stateIndex,
+          name: jobStateName(stateIndex),
+        },
+      };
+    }
+  }
+
+  return {
+    owner,
+    configuration,
+    modules: modulesSummary,
+    timings: timingsSummary,
+    thresholds: thresholdsSummary,
+    job: jobSummary,
+  };
+}
+
+function requireJobPresent(jobId, jobRaw) {
+  const stateIndex = jobRaw.state.toNumber();
+  if (stateIndex === 0 && jobRaw.client === '0x0000000000000000000000000000000000000000') {
+    throw new Error(`Job ${jobId} has not been created`);
+  }
+}
+
+function requireStateIn(jobId, jobRaw, allowedStates) {
+  const stateIndex = jobRaw.state.toNumber();
+  if (!allowedStates.includes(stateIndex)) {
+    throw new Error(
+      `Job ${jobId} cannot perform this action from state ${jobStateName(stateIndex)} (${stateIndex})`
+    );
+  }
+}
+
+function bnFrom(web3, value, label, { allowNegative = false } = {}) {
+  const { BN } = web3.utils;
+  try {
+    const bn = new BN(value ?? '0');
+    if (!allowNegative && bn.isNeg()) {
+      throw new Error(`${label} must not be negative`);
+    }
+    return bn;
+  } catch (error) {
+    if (error && error.message && error.message.includes('not a number')) {
+      throw new Error(`Unable to parse ${label} from "${value}"`);
+    }
+    throw error;
+  }
+}
+
+function buildDeadlineSummary(before, extensions) {
+  return {
+    before: {
+      commitDeadline: before.commitDeadline.clone(),
+      revealDeadline: before.revealDeadline.clone(),
+      disputeDeadline: before.disputeDeadline.clone(),
+    },
+    after: {
+      commitDeadline: before.commitDeadline.add(extensions.commit),
+      revealDeadline: before.revealDeadline.add(extensions.reveal),
+      disputeDeadline: before.disputeDeadline.add(extensions.dispute),
+    },
+  };
+}
+
+async function buildOwnerTxPlan({ registry, web3, options }) {
+  const action = options.action || 'status';
+  if (action === 'status') {
+    throw new Error(
+      'Status action does not produce a transaction plan. Call collectOwnerStatus instead.'
+    );
+  }
+
+  const { BN } = web3.utils;
+  if (!options.jobId) {
+    throw new Error('jobId is required for owner actions');
+  }
+  const jobIdBn = new BN(options.jobId);
+  const jobRaw = await registry.jobs(jobIdBn);
+  requireJobPresent(jobIdBn.toString(), jobRaw);
+
+  const stakeAmount = jobRaw.stakeAmount.clone
+    ? jobRaw.stakeAmount.clone()
+    : new BN(jobRaw.stakeAmount);
+  const thresholds = await registry.thresholds();
+  const slashBpsMax = new BN(thresholds.slashBpsMax.toString());
+  const feeBps = new BN(thresholds.feeBps.toString());
+  const metadata = {
+    jobId: jobIdBn.toString(),
+    client: jobRaw.client,
+    worker: jobRaw.worker,
+    stakeAmount,
+    state: {
+      value: jobRaw.state.toNumber(),
+      name: jobStateName(jobRaw.state.toNumber()),
+    },
+  };
+
+  if (action === 'extend') {
+    const commitExtension = bnFrom(web3, options.commitExtension || '0', 'commitExtension');
+    const revealExtension = bnFrom(web3, options.revealExtension || '0', 'revealExtension');
+    const disputeExtension = bnFrom(web3, options.disputeExtension || '0', 'disputeExtension');
+
+    if (commitExtension.isZero() && revealExtension.isZero() && disputeExtension.isZero()) {
+      throw new Error('At least one extension value must be greater than zero');
+    }
+
+    requireStateIn(metadata.jobId, jobRaw, [1, 2, 3]);
+
+    const deadlines = buildDeadlineSummary(
+      {
+        commitDeadline: jobRaw.commitDeadline.clone
+          ? jobRaw.commitDeadline.clone()
+          : new BN(jobRaw.commitDeadline),
+        revealDeadline: jobRaw.revealDeadline.clone
+          ? jobRaw.revealDeadline.clone()
+          : new BN(jobRaw.revealDeadline),
+        disputeDeadline: jobRaw.disputeDeadline.clone
+          ? jobRaw.disputeDeadline.clone()
+          : new BN(jobRaw.disputeDeadline),
+      },
+      {
+        commit: commitExtension,
+        reveal: revealExtension,
+        dispute: disputeExtension,
+      }
+    );
+
+    return {
+      action: 'extend',
+      method: 'extendJobDeadlines',
+      args: [
+        metadata.jobId,
+        commitExtension.toString(),
+        revealExtension.toString(),
+        disputeExtension.toString(),
+      ],
+      metadata: {
+        ...metadata,
+        deadlines,
+      },
+      warnings: [],
+    };
+  }
+
+  if (action === 'finalize') {
+    requireStateIn(metadata.jobId, jobRaw, [3]);
+
+    const feeAmount = stakeAmount.mul(feeBps).div(new BN(BPS_DENOMINATOR));
+
+    return {
+      action: 'finalize',
+      method: 'finalizeJob',
+      args: [metadata.jobId, Boolean(options.success)],
+      metadata: {
+        ...metadata,
+        success: Boolean(options.success),
+        feeAmount,
+      },
+      warnings: [],
+    };
+  }
+
+  if (action === 'timeout') {
+    requireStateIn(metadata.jobId, jobRaw, [2]);
+
+    const slashAmount = bnFrom(web3, options.slashAmount || '0', 'slashAmount');
+    if (slashAmount.gt(stakeAmount)) {
+      throw new Error('slashAmount must not exceed the job stake amount');
+    }
+
+    const maxSlash = stakeAmount.mul(slashBpsMax).div(new BN(BPS_DENOMINATOR));
+    if (slashAmount.gt(maxSlash)) {
+      throw new Error(
+        `slashAmount exceeds the configured maximum (${maxSlash.toString()}) for job ${metadata.jobId}`
+      );
+    }
+
+    return {
+      action: 'timeout',
+      method: 'timeoutJob',
+      args: [metadata.jobId, slashAmount.toString()],
+      metadata: {
+        ...metadata,
+        slashAmount,
+        maxSlash,
+      },
+      warnings: [],
+    };
+  }
+
+  if (action === 'resolve') {
+    requireStateIn(metadata.jobId, jobRaw, [5]);
+
+    const slashWorker = Boolean(options.slashWorker);
+    const slashAmount = bnFrom(web3, options.slashAmount || '0', 'slashAmount');
+    if (!slashWorker && !slashAmount.isZero()) {
+      throw new Error('slashAmount must be zero when slashWorker is false');
+    }
+
+    if (slashAmount.gt(stakeAmount)) {
+      throw new Error('slashAmount must not exceed the job stake amount');
+    }
+
+    const maxSlash = stakeAmount.mul(slashBpsMax).div(new BN(BPS_DENOMINATOR));
+    if (slashAmount.gt(maxSlash)) {
+      throw new Error(
+        `slashAmount exceeds the configured maximum (${maxSlash.toString()}) for job ${metadata.jobId}`
+      );
+    }
+
+    const reputationDelta = options.reputationDelta || '0';
+
+    return {
+      action: 'resolve',
+      method: 'resolveDispute',
+      args: [metadata.jobId, slashWorker, slashAmount.toString(), reputationDelta],
+      metadata: {
+        ...metadata,
+        slashWorker,
+        slashAmount,
+        reputationDelta,
+        maxSlash,
+      },
+      warnings: [],
+    };
+  }
+
+  throw new Error(`Unsupported owner console action: ${action}`);
+}
+
+function formatStatusLines(status) {
+  const lines = [];
+  lines.push(`Owner: ${status.owner}`);
+  lines.push('Configuration status:');
+  lines.push(`  modules: ${status.configuration.modules ? 'configured' : 'incomplete'}`);
+  lines.push(`  timings: ${status.configuration.timings ? 'configured' : 'incomplete'}`);
+  lines.push(`  thresholds: ${status.configuration.thresholds ? 'configured' : 'incomplete'}`);
+  lines.push('Modules:');
+  Object.entries(status.modules).forEach(([key, value]) => {
+    lines.push(`  ${key}: ${value}`);
+  });
+  lines.push('Timings (seconds):');
+  Object.entries(status.timings).forEach(([key, value]) => {
+    lines.push(`  ${key}: ${value}`);
+  });
+  lines.push('Thresholds:');
+  Object.entries(status.thresholds).forEach(([key, value]) => {
+    lines.push(`  ${key}: ${value}`);
+  });
+
+  if (status.job) {
+    lines.push('Job summary:');
+    lines.push(`  id: ${status.job.id}`);
+    lines.push(`  state: ${status.job.state.name} (${status.job.state.value})`);
+    lines.push(`  client: ${status.job.client}`);
+    lines.push(`  worker: ${status.job.worker}`);
+    lines.push(`  stakeAmount: ${status.job.stakeAmount}`);
+    lines.push(`  commitDeadline: ${status.job.commitDeadline}`);
+    lines.push(`  revealDeadline: ${status.job.revealDeadline}`);
+    lines.push(`  disputeDeadline: ${status.job.disputeDeadline}`);
+    lines.push(`  commitHash: ${status.job.commitHash}`);
+  }
+
+  return lines;
+}
+
+function formatTxPlanLines(plan, callData, { to }) {
+  const lines = [];
+  lines.push(`Action: ${plan.action}`);
+  lines.push(`  jobId: ${plan.metadata.jobId}`);
+  lines.push(`  current state: ${plan.metadata.state.name} (${plan.metadata.state.value})`);
+  lines.push(`  client: ${plan.metadata.client}`);
+  lines.push(`  worker: ${plan.metadata.worker}`);
+  lines.push(`  stakeAmount: ${plan.metadata.stakeAmount.toString()}`);
+
+  if (plan.action === 'extend') {
+    const { before, after } = plan.metadata.deadlines;
+    lines.push('  deadlines:');
+    lines.push(
+      `    commit: ${before.commitDeadline.toString()} -> ${after.commitDeadline.toString()}`
+    );
+    lines.push(
+      `    reveal: ${before.revealDeadline.toString()} -> ${after.revealDeadline.toString()}`
+    );
+    lines.push(
+      `    dispute: ${before.disputeDeadline.toString()} -> ${after.disputeDeadline.toString()}`
+    );
+  }
+
+  if (plan.action === 'finalize') {
+    lines.push(`  success flag: ${plan.metadata.success}`);
+    lines.push(`  feeAmount: ${plan.metadata.feeAmount.toString()}`);
+  }
+
+  if (plan.action === 'timeout') {
+    lines.push(`  slashAmount: ${plan.metadata.slashAmount.toString()}`);
+    lines.push(`  maxSlash: ${plan.metadata.maxSlash.toString()}`);
+  }
+
+  if (plan.action === 'resolve') {
+    lines.push(`  slashWorker: ${plan.metadata.slashWorker}`);
+    lines.push(`  slashAmount: ${plan.metadata.slashAmount.toString()}`);
+    lines.push(`  maxSlash: ${plan.metadata.maxSlash.toString()}`);
+    lines.push(`  reputationDelta: ${plan.metadata.reputationDelta}`);
+  }
+
+  lines.push('Transaction payload:');
+  lines.push(`  to: ${to}`);
+  lines.push(`  method: ${plan.method}`);
+  lines.push(`  args: ${JSON.stringify(plan.args)}`);
+  lines.push(`  data: ${callData}`);
+
+  return lines;
+}
+
+module.exports = {
+  JOB_STATE_NAMES,
+  BPS_DENOMINATOR,
+  parseOwnerConsoleArgs,
+  collectOwnerStatus,
+  buildOwnerTxPlan,
+  formatStatusLines,
+  formatTxPlanLines,
+};

--- a/test/jobRegistryOwnerConsole.test.js
+++ b/test/jobRegistryOwnerConsole.test.js
@@ -1,0 +1,262 @@
+const { expect } = require('chai');
+const { time } = require('@openzeppelin/test-helpers');
+
+const IdentityRegistry = artifacts.require('IdentityRegistry');
+const StakeManager = artifacts.require('StakeManager');
+const FeePool = artifacts.require('FeePool');
+const ValidationModule = artifacts.require('ValidationModule');
+const DisputeModule = artifacts.require('DisputeModule');
+const ReputationEngine = artifacts.require('ReputationEngine');
+const JobRegistry = artifacts.require('JobRegistry');
+const MockERC20 = artifacts.require('MockERC20');
+
+const {
+  parseOwnerConsoleArgs,
+  collectOwnerStatus,
+  buildOwnerTxPlan,
+  JOB_STATE_NAMES,
+} = require('../scripts/lib/job-registry-owner');
+
+async function expectAsyncError(promise, message) {
+  try {
+    await promise;
+    expect.fail('Expected promise to be rejected');
+  } catch (error) {
+    expect(error.message).to.include(message);
+  }
+}
+
+contract('JobRegistry owner console helpers', (accounts) => {
+  const [deployer, worker, client, burnAddress] = accounts;
+  const stakeAmount = web3.utils.toBN('500');
+  const initialStake = web3.utils.toBN('1000000');
+
+  beforeEach(async function () {
+    this.identity = await IdentityRegistry.new({ from: deployer });
+    this.token = await MockERC20.new('Stake', 'STK', 18, worker, initialStake, { from: deployer });
+    this.stakeManager = await StakeManager.new(this.token.address, 18, { from: deployer });
+    this.feePool = await FeePool.new(this.token.address, burnAddress, { from: deployer });
+    this.validation = await ValidationModule.new({ from: deployer });
+    this.dispute = await DisputeModule.new({ from: deployer });
+    this.reputation = await ReputationEngine.new({ from: deployer });
+    this.jobRegistry = await JobRegistry.new({ from: deployer });
+
+    await this.jobRegistry.setModules(
+      {
+        identity: this.identity.address,
+        staking: this.stakeManager.address,
+        validation: this.validation.address,
+        dispute: this.dispute.address,
+        reputation: this.reputation.address,
+        feePool: this.feePool.address,
+      },
+      { from: deployer }
+    );
+    await this.stakeManager.setJobRegistry(this.jobRegistry.address, { from: deployer });
+    await this.stakeManager.setFeeRecipient(this.feePool.address, { from: deployer });
+    await this.feePool.setJobRegistry(this.jobRegistry.address, { from: deployer });
+    await this.dispute.setJobRegistry(this.jobRegistry.address, { from: deployer });
+    await this.reputation.setJobRegistry(this.jobRegistry.address, { from: deployer });
+    await this.jobRegistry.setTimings(3600, 3600, 7200, { from: deployer });
+    await this.jobRegistry.setThresholds(6000, 1, 11, 250, 2000, { from: deployer });
+
+    await this.token.approve(this.stakeManager.address, initialStake, { from: worker });
+    await this.stakeManager.deposit(initialStake, { from: worker });
+  });
+
+  function randomSecret() {
+    return web3.utils.randomHex(32);
+  }
+
+  async function createJobLifecycle(context) {
+    const { jobRegistry } = context;
+    const { logs } = await jobRegistry.createJob(stakeAmount, { from: client });
+    const jobId = logs.find((log) => log.event === 'JobCreated').args.jobId;
+    return jobId;
+  }
+
+  async function commitJob(context, jobId) {
+    const secret = randomSecret();
+    const hash = web3.utils.soliditySha3({ type: 'bytes32', value: secret });
+    await context.jobRegistry.commitJob(jobId, hash, { from: worker });
+    return secret;
+  }
+
+  it('parses owner console arguments and positional action', () => {
+    const argv = [
+      'node',
+      'script.js',
+      '--from',
+      '0x1234567890123456789012345678901234567890',
+      '--execute=false',
+      '--job',
+      '7',
+      '--slash-worker',
+      '--reputation-delta',
+      '-3',
+      'resolve',
+    ];
+
+    const parsed = parseOwnerConsoleArgs(argv);
+    expect(parsed.action).to.equal('resolve');
+    expect(parsed.from).to.equal('0x1234567890123456789012345678901234567890');
+    expect(parsed.execute).to.be.false;
+    expect(parsed.jobId).to.equal('7');
+    expect(parsed.slashWorker).to.be.true;
+    expect(parsed.reputationDelta).to.equal('-3');
+  });
+
+  it('collects status with job summary', async function () {
+    const jobId = await createJobLifecycle(this);
+    const status = await collectOwnerStatus({
+      registry: this.jobRegistry,
+      web3,
+      owner: deployer,
+      jobId: jobId.toString(),
+    });
+
+    expect(status.owner).to.equal(deployer);
+    expect(status.configuration.modules).to.be.true;
+    expect(status.job.id).to.equal(jobId.toString());
+    expect(status.job.state.name).to.equal(JOB_STATE_NAMES[1]);
+  });
+
+  it('builds an extend plan and updates deadlines', async function () {
+    const jobId = await createJobLifecycle(this);
+    const plan = await buildOwnerTxPlan({
+      registry: this.jobRegistry,
+      web3,
+      options: {
+        action: 'extend',
+        jobId: jobId.toString(),
+        commitExtension: '900',
+        revealExtension: '0',
+        disputeExtension: '0',
+      },
+    });
+
+    expect(plan.method).to.equal('extendJobDeadlines');
+    expect(plan.args[1]).to.equal('900');
+
+    const before = await this.jobRegistry.jobs(jobId);
+    const initialCommitDeadline = before.commitDeadline;
+
+    await this.jobRegistry.extendJobDeadlines(jobId, 900, 0, 0, { from: deployer });
+    const after = await this.jobRegistry.jobs(jobId);
+    expect(after.commitDeadline.sub(initialCommitDeadline).toString()).to.equal('900');
+  });
+
+  it('builds a finalize plan and reports fee amount', async function () {
+    const jobId = await createJobLifecycle(this);
+    const secret = await commitJob(this, jobId);
+    await this.jobRegistry.revealJob(jobId, secret, { from: worker });
+
+    const plan = await buildOwnerTxPlan({
+      registry: this.jobRegistry,
+      web3,
+      options: {
+        action: 'finalize',
+        jobId: jobId.toString(),
+        success: false,
+      },
+    });
+
+    expect(plan.method).to.equal('finalizeJob');
+    expect(plan.metadata.feeAmount.toString()).to.equal(
+      stakeAmount.muln(250).divn(10000).toString()
+    );
+
+    await this.jobRegistry.finalizeJob(jobId, false, { from: deployer });
+    const job = await this.jobRegistry.jobs(jobId);
+    expect(job.state.toNumber()).to.equal(4);
+  });
+
+  it('builds a resolve plan with slashing', async function () {
+    const jobId = await createJobLifecycle(this);
+    const secret = await commitJob(this, jobId);
+    await this.jobRegistry.revealJob(jobId, secret, { from: worker });
+    await this.jobRegistry.raiseDispute(jobId, { from: client });
+
+    const plan = await buildOwnerTxPlan({
+      registry: this.jobRegistry,
+      web3,
+      options: {
+        action: 'resolve',
+        jobId: jobId.toString(),
+        slashWorker: true,
+        slashAmount: '80',
+        reputationDelta: '-1',
+      },
+    });
+
+    expect(plan.method).to.equal('resolveDispute');
+    expect(plan.metadata.slashAmount.toString()).to.equal('80');
+
+    await this.jobRegistry.resolveDispute(jobId, true, 80, '-1', { from: deployer });
+    const job = await this.jobRegistry.jobs(jobId);
+    expect(job.state.toNumber()).to.equal(4);
+  });
+
+  it('builds a timeout plan and enforces slash ceilings', async function () {
+    const jobId = await createJobLifecycle(this);
+    await commitJob(this, jobId);
+
+    const plan = await buildOwnerTxPlan({
+      registry: this.jobRegistry,
+      web3,
+      options: {
+        action: 'timeout',
+        jobId: jobId.toString(),
+        slashAmount: '10',
+      },
+    });
+
+    expect(plan.method).to.equal('timeoutJob');
+
+    const job = await this.jobRegistry.jobs(jobId);
+    const disputeDeadline = job.disputeDeadline.addn(1);
+    await time.increaseTo(disputeDeadline);
+    await this.jobRegistry.timeoutJob(jobId, 10, { from: deployer });
+    const updated = await this.jobRegistry.jobs(jobId);
+    expect(updated.state.toNumber()).to.equal(4);
+  });
+
+  it('rejects extend plan when all extensions are zero', async function () {
+    const jobId = await createJobLifecycle(this);
+    await expectAsyncError(
+      buildOwnerTxPlan({
+        registry: this.jobRegistry,
+        web3,
+        options: {
+          action: 'extend',
+          jobId: jobId.toString(),
+          commitExtension: '0',
+          revealExtension: '0',
+          disputeExtension: '0',
+        },
+      }),
+      'At least one extension value must be greater than zero'
+    );
+  });
+
+  it('rejects resolve plan with slash exceeding limits', async function () {
+    const jobId = await createJobLifecycle(this);
+    const secret = await commitJob(this, jobId);
+    await this.jobRegistry.revealJob(jobId, secret, { from: worker });
+    await this.jobRegistry.raiseDispute(jobId, { from: client });
+
+    await expectAsyncError(
+      buildOwnerTxPlan({
+        registry: this.jobRegistry,
+        web3,
+        options: {
+          action: 'resolve',
+          jobId: jobId.toString(),
+          slashWorker: true,
+          slashAmount: stakeAmount.muln(3).toString(),
+        },
+      }),
+      'slashAmount must not exceed the job stake amount'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a JobRegistry owner console script with dry-run output, Safe-ready payloads, and owner checks
- factor reusable helpers for parsing, status collection, and invariant-aware transaction planning
- document the new workflow, expose an npm script entry point, and cover owner console actions in tests

## Testing
- npm run test
- npm run lint:sol

------
https://chatgpt.com/codex/tasks/task_e_68d1897fab348333b192ba7c97a623d9