### PR TITLE
Add JobRegistry config console and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Edit configuration files under `config/` to match the deployment environment:
 ### JobRegistry configuration helper
 
 - Execute `npm run configure:registry` for a non-destructive dry run that compares the on-chain JobRegistry wiring, lifecycle
+
   timings, and governance thresholds against the repository defaults. The summary highlights any drift and prints the sender,
   owner, and params profile so operators can confirm the context before acting.
 - Pass `-- --execute --from 0xYourOwnerAddress` to broadcast updates from an authorized account. The helper automatically
@@ -65,6 +66,12 @@ Edit configuration files under `config/` to match the deployment environment:
   `--modules.identity` or `--thresholds.feeBps`), and validates all numerical constraints before submitting transactions.
 - Override the default configuration profile with `-- --params /path/to/params.json` when staging alternate environments, or
   use `-- --variant sepolia` to label the summary with the intended target network.
+
+### JobRegistry configuration console
+
+- Call `npm run config:console -- --network <network> status` for a concise snapshot of module wiring, lifecycle timings, and threshold values along with the configuration completeness flags.
+- Switch to `set` to align on-chain values with repository defaults or explicit overrides using the same flags accepted by `configure:registry`; dry runs print the planned diffs and `-- --execute` broadcasts `setModules`, `setTimings`, and `setThresholds` transactions sequentially.
+- Use the `update` action with a single `--modules.<key>`, `--timings.<key>`, or `--thresholds.<key>` flag to invoke the granular update functions. The console validates invariants, emits a Safe-ready transaction payload during dry runs, and refuses zero-address or misordered quorum updates before touching the chain.
 
 ### JobRegistry owner console
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",
     "config:validate": "node scripts/validate-config.js",
     "prepare": "husky install",
-    "hardhat:test": "node scripts/run-tests.js"
+    "hardhat:test": "node scripts/run-tests.js",
+    "config:console": "npx truffle exec scripts/job-registry-config-console.js --network ${NETWORK:-development}"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.3",

--- a/scripts/job-registry-config-console.js
+++ b/scripts/job-registry-config-console.js
@@ -1,0 +1,321 @@
+const JobRegistry = artifacts.require('JobRegistry');
+
+const {
+  ACTIONS,
+  parseConfigConsoleArgs,
+  buildSetPlans,
+  buildUpdatePlan,
+  formatPlanDiff,
+} = require('./lib/job-registry-config-console');
+const {
+  extractNetwork,
+  loadParamsConfig,
+  toChecksum,
+  formatAddress,
+  formatDiffEntry,
+  normalizeModuleStruct,
+  normalizeNumericStruct,
+} = require('./lib/job-registry-config-utils');
+const { resolveModuleDefaults } = require('./lib/job-registry-config-defaults');
+const { resolveVariant } = require('./config-loader');
+const { TIMING_KEYS, THRESHOLD_KEYS } = require('./lib/job-registry-configurator');
+
+function printHelp() {
+  console.log('AGI Jobs v1 — JobRegistry configuration console');
+  console.log(
+    'Usage: npx truffle exec scripts/job-registry-config-console.js --network <network> [action] [options]'
+  );
+  console.log('');
+  console.log('Actions:');
+  console.log('  status   Display current configuration (default)');
+  console.log(
+    '  set      Align on-chain configuration with config files and overrides (uses setModules/setTimings/setThresholds)'
+  );
+  console.log(
+    '  update   Update a single module/timing/threshold using updateModule/updateTiming/updateThreshold'
+  );
+  console.log('');
+  console.log('Common options:');
+  console.log('  --from <address>         Sender address (defaults to first unlocked account)');
+  console.log('  --execute[=true|false]  Broadcast transaction instead of dry run');
+  console.log('  --dry-run[=true|false]  Alias for --execute');
+  console.log('  --params <path>         Override params JSON path (set action)');
+  console.log('  --variant <name>        Optional environment hint for logging');
+  console.log('  --help                  Show this message');
+  console.log('');
+  console.log('Set action overrides:');
+  console.log('  --modules.<key> <address>     identity, staking, validation, dispute, reputation, feePool');
+  console.log('  --timings.<key> <seconds>     commitWindow, revealWindow, disputeWindow');
+  console.log(
+    '  --thresholds.<key> <value>   approvalThresholdBps, quorumMin, quorumMax, feeBps, slashBpsMax'
+  );
+  console.log('');
+  console.log('Update action example:');
+  console.log(
+    '  npx truffle exec scripts/job-registry-config-console.js --network mainnet update --thresholds.feeBps 275'
+  );
+}
+
+function printSection(label, values, formatter) {
+  console.log(`- ${label}:`);
+  const entries = Object.entries(values || {});
+  if (entries.length === 0) {
+    console.log('    (no data)');
+    return;
+  }
+  entries.forEach(([key, value]) => {
+    if (value === null || value === undefined) {
+      console.log(`    ${key}: (unset)`);
+    } else {
+      console.log(`    ${key}: ${formatter(value)}`);
+    }
+  });
+}
+
+function printDiffSection(label, diff, formatter) {
+  const entries = Object.entries(diff);
+  if (entries.length === 0) {
+    console.log(`- ${label}: no changes required.`);
+    return;
+  }
+  console.log(`- ${label}:`);
+  entries.forEach(([key, { previous, next }]) => {
+    console.log(`    ${key}: ${formatDiffEntry(previous, next, formatter)}`);
+  });
+}
+
+function describeConfigurationStatus(status) {
+  const icons = (value) => (value ? '✓' : '✗');
+  return `modules=${icons(status.modules)} timings=${icons(status.timings)} thresholds=${icons(status.thresholds)}`;
+}
+
+module.exports = async function (callback) {
+  try {
+    const options = parseConfigConsoleArgs(process.argv);
+    if (options.help) {
+      printHelp();
+      callback();
+      return;
+    }
+
+    const action = options.action || ACTIONS.STATUS;
+    if (!Object.values(ACTIONS).includes(action)) {
+      throw new Error(`Unsupported action "${options.action}". Use status, set, or update.`);
+    }
+
+    const networkName =
+      extractNetwork(process.argv) || process.env.NETWORK || process.env.TRUFFLE_NETWORK || null;
+
+    let resolvedVariant = null;
+    if (options.variant || networkName) {
+      try {
+        resolvedVariant = resolveVariant(options.variant || networkName);
+      } catch (error) {
+        console.warn(
+          `Warning: unable to resolve variant for "${options.variant || networkName}": ${error.message}`
+        );
+      }
+    }
+
+    const jobRegistry = await JobRegistry.deployed();
+    const jobRegistryAddress = toChecksum(jobRegistry.address);
+    const owner = toChecksum(await jobRegistry.owner());
+
+    const accounts = await web3.eth.getAccounts();
+    const senderOverride = options.from || process.env.CONFIGURE_REGISTRY_FROM || null;
+    const sender = senderOverride
+      ? toChecksum(senderOverride)
+      : accounts[0]
+        ? toChecksum(accounts[0])
+        : null;
+
+    if (!sender) {
+      throw new Error('No sender account is available. Specify --from or unlock an account.');
+    }
+
+    const [modules, timings, thresholds, configStatus] = await Promise.all([
+      jobRegistry.modules(),
+      jobRegistry.timings(),
+      jobRegistry.thresholds(),
+      jobRegistry.configurationStatus(),
+    ]);
+
+    const currentModules = normalizeModuleStruct(modules);
+    const currentTimings = normalizeNumericStruct(timings, TIMING_KEYS);
+    const currentThresholds = normalizeNumericStruct(thresholds, THRESHOLD_KEYS);
+    const configuration = {
+      modules: Boolean(configStatus[0]),
+      timings: Boolean(configStatus[1]),
+      thresholds: Boolean(configStatus[2]),
+    };
+
+    console.log('AGIJobsv1 — JobRegistry configuration console');
+    console.log(`Action: ${action}`);
+    console.log(
+      `Network: ${networkName || '(unspecified)'}${resolvedVariant ? ` (variant: ${resolvedVariant})` : ''}`
+    );
+    console.log(`JobRegistry: ${jobRegistryAddress}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log(`Sender: ${sender}`);
+    console.log(`Configuration: ${describeConfigurationStatus(configuration)}`);
+    console.log('');
+
+    if (action === ACTIONS.STATUS) {
+      printSection('Modules', currentModules, (value) => formatAddress(value));
+      console.log('');
+      printSection('Timings', currentTimings, (value) => `${value} seconds`);
+      console.log('');
+      printSection('Thresholds', currentThresholds, (value) => `${value}`);
+      callback();
+      return;
+    }
+
+    const shouldExecute = Boolean(options.execute);
+    if (owner && owner.toLowerCase() !== sender.toLowerCase()) {
+      console.warn(
+        `Warning: sender ${sender} is not the JobRegistry owner (${owner}). Transactions may revert unless forwarded through the owner.`
+      );
+    }
+
+    if (action === ACTIONS.SET) {
+      const paramsConfig = loadParamsConfig(options.paramsPath);
+      const moduleDefaults = await resolveModuleDefaults(options.modules);
+      const plans = buildSetPlans({
+        currentModules,
+        currentTimings,
+        currentThresholds,
+        overrides: {
+          modules: options.modules,
+          timings: options.timings,
+          thresholds: options.thresholds,
+        },
+        defaults: {
+          modules: moduleDefaults,
+          timings: paramsConfig.values,
+          thresholds: paramsConfig.values,
+        },
+      });
+
+      console.log(`Params file: ${paramsConfig.path}`);
+      console.log('');
+      console.log('Planned updates:');
+      printDiffSection('Modules', plans.modulesPlan.diff, (value) => formatAddress(value));
+      printDiffSection('Timings', plans.timingsPlan.diff, (value) => `${value} seconds`);
+      printDiffSection('Thresholds', plans.thresholdsPlan.diff, (value) => `${value}`);
+
+      const actions = [];
+      if (plans.modulesPlan.changed) {
+        actions.push(async () => {
+          console.log('Executing setModules…');
+          const receipt = await jobRegistry.setModules(plans.modulesPlan.desired, { from: sender });
+          console.log(`  ✓ setModules tx: ${receipt.tx}`);
+        });
+      }
+      if (plans.timingsPlan.changed) {
+        actions.push(async () => {
+          console.log('Executing setTimings…');
+          const { commitWindow, revealWindow, disputeWindow } = plans.timingsPlan.desired;
+          const receipt = await jobRegistry.setTimings(commitWindow, revealWindow, disputeWindow, {
+            from: sender,
+          });
+          console.log(`  ✓ setTimings tx: ${receipt.tx}`);
+        });
+      }
+      if (plans.thresholdsPlan.changed) {
+        actions.push(async () => {
+          console.log('Executing setThresholds…');
+          const { approvalThresholdBps, quorumMin, quorumMax, feeBps, slashBpsMax } =
+            plans.thresholdsPlan.desired;
+          const receipt = await jobRegistry.setThresholds(
+            approvalThresholdBps,
+            quorumMin,
+            quorumMax,
+            feeBps,
+            slashBpsMax,
+            { from: sender }
+          );
+          console.log(`  ✓ setThresholds tx: ${receipt.tx}`);
+        });
+      }
+
+      if (actions.length === 0) {
+        console.log('\nAll sections already match the desired configuration.');
+        callback();
+        return;
+      }
+
+      if (!shouldExecute) {
+        console.log('\nDry run complete — re-run with --execute to broadcast the above changes.');
+        callback();
+        return;
+      }
+
+      for (const actionFn of actions) {
+        await actionFn();
+      }
+
+      console.log('\nConfiguration updates applied successfully.');
+      callback();
+      return;
+    }
+
+    if (action === ACTIONS.UPDATE) {
+      const plan = buildUpdatePlan({
+        overrides: {
+          modules: options.modules,
+          timings: options.timings,
+          thresholds: options.thresholds,
+        },
+        currentModules,
+        currentTimings,
+        currentThresholds,
+      });
+
+      const formatter = plan.summary.section === 'modules'
+        ? (value) => formatAddress(value)
+        : plan.summary.section === 'timings'
+          ? (value) => `${value} seconds`
+          : (value) => `${value}`;
+
+      console.log('Planned single-field update:');
+      console.log(
+        `- ${plan.summary.section}.${plan.summary.key}: ${formatPlanDiff(plan.summary, formatter)}`
+      );
+
+      const callData = jobRegistry.contract.methods[plan.method](...plan.args).encodeABI();
+
+      if (!shouldExecute) {
+        console.log('Dry run: transaction not broadcast.');
+        console.log(
+          JSON.stringify(
+            {
+              to: jobRegistry.address,
+              from: sender,
+              data: callData,
+              value: '0',
+              description: `JobRegistry.${plan.method}`,
+              arguments: plan.args,
+            },
+            null,
+            2
+          )
+        );
+        callback();
+        return;
+      }
+
+      if (!owner || owner.toLowerCase() !== sender.toLowerCase()) {
+        throw new Error(`Sender ${sender} is not the JobRegistry owner (${owner}).`);
+      }
+
+      const receipt = await jobRegistry[plan.method](...plan.args, { from: sender });
+      console.log(`Transaction broadcast. Hash: ${receipt.tx}`);
+      callback();
+      return;
+    }
+
+    throw new Error(`Unhandled action: ${action}`);
+  } catch (error) {
+    callback(error);
+  }
+};

--- a/scripts/lib/job-registry-config-console.js
+++ b/scripts/lib/job-registry-config-console.js
@@ -1,0 +1,295 @@
+'use strict';
+
+const {
+  parseConfiguratorArgs,
+  computeModulesPlan,
+  computeTimingsPlan,
+  computeThresholdsPlan,
+  normalizeAddress,
+  parsePositiveInteger,
+  parseNonNegativeInteger,
+  parseBps,
+  MODULE_KEYS,
+  TIMING_KEYS,
+  THRESHOLD_KEYS,
+} = require('./job-registry-configurator');
+const { formatDiffEntry } = require('./job-registry-config-utils');
+
+const ACTIONS = Object.freeze({
+  STATUS: 'status',
+  SET: 'set',
+  UPDATE: 'update',
+});
+
+const MODULE_ENUM = Object.freeze({
+  identity: 0,
+  staking: 1,
+  validation: 2,
+  dispute: 3,
+  reputation: 4,
+  feePool: 5,
+});
+
+const TIMING_ENUM = Object.freeze({
+  commitWindow: 0,
+  revealWindow: 1,
+  disputeWindow: 2,
+});
+
+const THRESHOLD_ENUM = Object.freeze({
+  approvalThresholdBps: 0,
+  quorumMin: 1,
+  quorumMax: 2,
+  feeBps: 3,
+  slashBpsMax: 4,
+});
+
+function findAction(argv) {
+  for (let i = 2; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (typeof value !== 'string') {
+      continue;
+    }
+    if (value.startsWith('--')) {
+      if (!value.includes('=') && i + 1 < argv.length) {
+        const next = argv[i + 1];
+        if (typeof next === 'string' && !next.startsWith('--')) {
+          i += 1; // skip paired value
+        }
+      }
+      continue;
+    }
+    return value;
+  }
+  return null;
+}
+
+function parseConfigConsoleArgs(argv) {
+  const parsed = parseConfiguratorArgs(argv);
+  const rawAction = findAction(argv);
+  const action = rawAction ? String(rawAction).toLowerCase() : ACTIONS.STATUS;
+  return {
+    ...parsed,
+    action,
+  };
+}
+
+function extractOverrideEntries(options) {
+  const entries = [];
+  if (options.modules) {
+    for (const key of MODULE_KEYS) {
+      const value = options.modules[key];
+      if (value !== undefined && value !== null) {
+        entries.push({ section: 'modules', key, value });
+      }
+    }
+  }
+  if (options.timings) {
+    for (const key of TIMING_KEYS) {
+      const value = options.timings[key];
+      if (value !== undefined && value !== null) {
+        entries.push({ section: 'timings', key, value });
+      }
+    }
+  }
+  if (options.thresholds) {
+    for (const key of THRESHOLD_KEYS) {
+      const value = options.thresholds[key];
+      if (value !== undefined && value !== null) {
+        entries.push({ section: 'thresholds', key, value });
+      }
+    }
+  }
+  return entries;
+}
+
+function buildSetPlans({ currentModules, currentTimings, currentThresholds, overrides, defaults }) {
+  const modulesPlan = computeModulesPlan({
+    current: currentModules,
+    overrides: overrides.modules,
+    defaults: defaults.modules,
+  });
+  const timingsPlan = computeTimingsPlan({
+    current: currentTimings,
+    overrides: overrides.timings,
+    defaults: defaults.timings,
+  });
+  const thresholdsPlan = computeThresholdsPlan({
+    current: currentThresholds,
+    overrides: overrides.thresholds,
+    defaults: defaults.thresholds,
+  });
+
+  return { modulesPlan, timingsPlan, thresholdsPlan };
+}
+
+function ensureSingleOverride(entries) {
+  if (entries.length === 0) {
+    throw new Error(
+      'Update action requires exactly one override flag. Provide a single --modules.<key>, --timings.<key>, or --thresholds.<key> option.'
+    );
+  }
+  if (entries.length > 1) {
+    const labels = entries.map((entry) => `${entry.section}.${entry.key}`).join(', ');
+    throw new Error(`Update action accepts only one override but received: ${labels}`);
+  }
+  return entries[0];
+}
+
+function validateModuleOverride({ key, value, currentModules }) {
+  const label = `modules.${key}`;
+  const normalized = normalizeAddress(value, label);
+  if (normalized === '0x0000000000000000000000000000000000000000') {
+    throw new Error(`${label} must not be the zero address`);
+  }
+  const previous = currentModules && currentModules[key] ? String(currentModules[key]) : null;
+  if (previous && previous.toLowerCase() === normalized.toLowerCase()) {
+    throw new Error(`${label} already equals the requested address`);
+  }
+  const index = MODULE_ENUM[key];
+  if (index === undefined) {
+    throw new Error(`Unknown module key "${key}"`);
+  }
+  return {
+    method: 'updateModule',
+    args: [index, normalized],
+    summary: {
+      section: 'modules',
+      key,
+      previous,
+      next: normalized,
+    },
+  };
+}
+
+function validateTimingOverride({ key, value, currentTimings }) {
+  const label = `timings.${key}`;
+  const parsedValue = parsePositiveInteger(value, label);
+  const previous = currentTimings && currentTimings[key] !== undefined ? currentTimings[key] : null;
+  if (previous !== null && Number(previous) === Number(parsedValue)) {
+    throw new Error(`${label} already equals the requested value`);
+  }
+  const index = TIMING_ENUM[key];
+  if (index === undefined) {
+    throw new Error(`Unknown timing key "${key}"`);
+  }
+  return {
+    method: 'updateTiming',
+    args: [index, String(parsedValue)],
+    summary: {
+      section: 'timings',
+      key,
+      previous,
+      next: parsedValue,
+    },
+  };
+}
+
+function ensureThresholdInvariant({ key, value, currentThresholds }) {
+  const currentMin =
+    currentThresholds && currentThresholds.quorumMin !== null
+      ? Number(currentThresholds.quorumMin)
+      : null;
+  const currentMax =
+    currentThresholds && currentThresholds.quorumMax !== null
+      ? Number(currentThresholds.quorumMax)
+      : null;
+
+  if (key === 'quorumMin') {
+    const nextMin = Number(value);
+    if (nextMin <= 0) {
+      throw new Error('thresholds.quorumMin must be greater than zero');
+    }
+    if (currentMax !== null && nextMin > currentMax) {
+      throw new Error(
+        `thresholds.quorumMin (${nextMin}) must not exceed the current quorumMax (${currentMax})`
+      );
+    }
+  }
+
+  if (key === 'quorumMax') {
+    if (currentThresholds && currentThresholds.quorumMin === null) {
+      throw new Error('thresholds.quorumMin must be configured before updating quorumMax');
+    }
+    const baseMin = currentThresholds ? Number(currentThresholds.quorumMin) : null;
+    const nextMax = Number(value);
+    if (baseMin !== null && nextMax < baseMin) {
+      throw new Error(
+        `thresholds.quorumMax (${nextMax}) must be greater than or equal to thresholds.quorumMin (${baseMin})`
+      );
+    }
+  }
+}
+
+function validateThresholdOverride({ key, value, currentThresholds }) {
+  const label = `thresholds.${key}`;
+  let parsedValue;
+  if (key === 'approvalThresholdBps' || key === 'feeBps' || key === 'slashBpsMax') {
+    parsedValue = parseBps(value, label);
+  } else if (key === 'quorumMin') {
+    parsedValue = parsePositiveInteger(value, label);
+  } else if (key === 'quorumMax') {
+    parsedValue = parseNonNegativeInteger(value, label);
+  } else {
+    throw new Error(`Unknown threshold key "${key}"`);
+  }
+
+  ensureThresholdInvariant({ key, value: parsedValue, currentThresholds });
+
+  const previous = currentThresholds && currentThresholds[key] !== undefined ? currentThresholds[key] : null;
+  if (previous !== null && Number(previous) === Number(parsedValue)) {
+    throw new Error(`${label} already equals the requested value`);
+  }
+
+  const index = THRESHOLD_ENUM[key];
+  return {
+    method: 'updateThreshold',
+    args: [index, String(parsedValue)],
+    summary: {
+      section: 'thresholds',
+      key,
+      previous,
+      next: parsedValue,
+    },
+  };
+}
+
+function buildUpdatePlan({ overrides, currentModules, currentTimings, currentThresholds }) {
+  const entries = extractOverrideEntries(overrides);
+  const override = ensureSingleOverride(entries);
+
+  if (override.section === 'modules') {
+    return validateModuleOverride({ key: override.key, value: override.value, currentModules });
+  }
+  if (override.section === 'timings') {
+    return validateTimingOverride({ key: override.key, value: override.value, currentTimings });
+  }
+  if (override.section === 'thresholds') {
+    if (!currentThresholds) {
+      throw new Error('Threshold configuration is unavailable on-chain');
+    }
+    return validateThresholdOverride({
+      key: override.key,
+      value: override.value,
+      currentThresholds,
+    });
+  }
+
+  throw new Error(`Unsupported override section "${override.section}"`);
+}
+
+function formatPlanDiff(summary, formatter = (value) => value) {
+  return formatDiffEntry(summary.previous, summary.next, formatter);
+}
+
+module.exports = {
+  ACTIONS,
+  MODULE_ENUM,
+  TIMING_ENUM,
+  THRESHOLD_ENUM,
+  parseConfigConsoleArgs,
+  extractOverrideEntries,
+  buildSetPlans,
+  buildUpdatePlan,
+  formatPlanDiff,
+};

--- a/scripts/lib/job-registry-config-defaults.js
+++ b/scripts/lib/job-registry-config-defaults.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const IdentityRegistry = artifacts.require('IdentityRegistry');
+const StakeManager = artifacts.require('StakeManager');
+const ValidationModule = artifacts.require('ValidationModule');
+const DisputeModule = artifacts.require('DisputeModule');
+const ReputationEngine = artifacts.require('ReputationEngine');
+const FeePool = artifacts.require('FeePool');
+
+const { MODULE_KEYS } = require('./job-registry-configurator');
+
+const MODULE_ARTIFACTS = {
+  identity: IdentityRegistry,
+  staking: StakeManager,
+  validation: ValidationModule,
+  dispute: DisputeModule,
+  reputation: ReputationEngine,
+  feePool: FeePool,
+};
+
+async function resolveModuleDefaults(overrides) {
+  const defaults = {};
+
+  for (const key of MODULE_KEYS) {
+    if (overrides[key] !== undefined && overrides[key] !== null) {
+      continue;
+    }
+
+    const artifact = MODULE_ARTIFACTS[key];
+    if (!artifact) {
+      continue;
+    }
+
+    try {
+      const instance = await artifact.deployed();
+      defaults[key] = instance.address;
+    } catch (error) {
+      throw new Error(
+        `Unable to determine default deployment for modules.${key}. Provide an explicit override with --modules.${key}.`
+      );
+    }
+  }
+
+  return defaults;
+}
+
+module.exports = {
+  MODULE_ARTIFACTS,
+  resolveModuleDefaults,
+};

--- a/scripts/lib/job-registry-config-utils.js
+++ b/scripts/lib/job-registry-config-utils.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { MODULE_KEYS, TIMING_KEYS, THRESHOLD_KEYS } = require('./job-registry-configurator');
+
+function extractNetwork(argv) {
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (typeof arg !== 'string' || !arg.startsWith('--')) {
+      continue;
+    }
+
+    const trimmed = arg.slice(2);
+    if (trimmed === 'network') {
+      const next = argv[i + 1];
+      if (next && typeof next === 'string' && !next.startsWith('--')) {
+        return next;
+      }
+    } else if (trimmed.startsWith('network=')) {
+      return trimmed.slice('network='.length);
+    }
+  }
+
+  return undefined;
+}
+
+function loadParamsConfig(paramsPath) {
+  const resolvedPath = paramsPath
+    ? path.resolve(paramsPath)
+    : path.join(__dirname, '..', '..', 'config', 'params.json');
+
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  return { path: resolvedPath, values: parsed };
+}
+
+function toChecksum(address, web3Instance) {
+  if (!address) {
+    return null;
+  }
+
+  const candidate = String(address);
+  const web3Ref =
+    web3Instance || (typeof web3 !== 'undefined' && web3 && web3.utils ? web3 : null);
+
+  if (web3Ref && web3Ref.utils && typeof web3Ref.utils.toChecksumAddress === 'function') {
+    try {
+      return web3Ref.utils.toChecksumAddress(candidate);
+    } catch (error) {
+      return candidate;
+    }
+  }
+
+  return candidate;
+}
+
+function formatAddress(address, web3Instance) {
+  const checksum = toChecksum(address, web3Instance);
+  return checksum ? checksum : '(unset)';
+}
+
+function formatDiffEntry(previous, next, formatter = (value) => value) {
+  const prevFormatted =
+    previous === null || previous === undefined ? '(unset)' : formatter(previous);
+  const nextFormatted = formatter(next);
+  return `${prevFormatted} -> ${nextFormatted}`;
+}
+
+function normalizeModuleStruct(struct) {
+  const normalized = {};
+  MODULE_KEYS.forEach((key, index) => {
+    let value = struct[key];
+    if (value === undefined) {
+      value = struct[index];
+    }
+    if (value === undefined || value === null || value === '') {
+      normalized[key] = null;
+    } else {
+      normalized[key] = String(value);
+    }
+  });
+  return normalized;
+}
+
+function normalizeNumericStruct(struct, keys) {
+  const normalized = {};
+  keys.forEach((key, index) => {
+    let value = struct[key];
+    if (value === undefined) {
+      value = struct[index];
+    }
+
+    if (value === undefined || value === null) {
+      normalized[key] = null;
+      return;
+    }
+
+    if (typeof value === 'number') {
+      normalized[key] = value;
+      return;
+    }
+
+    if (typeof value.toNumber === 'function') {
+      normalized[key] = value.toNumber();
+      return;
+    }
+
+    if (typeof value.toString === 'function') {
+      const asString = value.toString();
+      if (/^\d+$/.test(asString)) {
+        normalized[key] = Number(asString);
+        return;
+      }
+      normalized[key] = asString;
+      return;
+    }
+
+    normalized[key] = Number(value);
+  });
+  return normalized;
+}
+
+function collectConfigurationSnapshot(struct) {
+  return {
+    modules: normalizeModuleStruct(struct.modules),
+    timings: normalizeNumericStruct(struct.timings, TIMING_KEYS),
+    thresholds: normalizeNumericStruct(struct.thresholds, THRESHOLD_KEYS),
+  };
+}
+
+module.exports = {
+  extractNetwork,
+  loadParamsConfig,
+  toChecksum,
+  formatAddress,
+  formatDiffEntry,
+  normalizeModuleStruct,
+  normalizeNumericStruct,
+  collectConfigurationSnapshot,
+};

--- a/test/jobRegistryConfigConsole.test.js
+++ b/test/jobRegistryConfigConsole.test.js
@@ -1,0 +1,209 @@
+const { expect } = require('chai');
+
+const {
+  ACTIONS,
+  MODULE_ENUM,
+  TIMING_ENUM,
+  THRESHOLD_ENUM,
+  parseConfigConsoleArgs,
+  buildSetPlans,
+  buildUpdatePlan,
+} = require('../scripts/lib/job-registry-config-console');
+const {
+  MODULE_KEYS,
+  TIMING_KEYS,
+  THRESHOLD_KEYS,
+  BPS_DENOMINATOR,
+} = require('../scripts/lib/job-registry-configurator');
+
+function addressOf(hexDigit) {
+  return `0x${hexDigit.repeat(40)}`;
+}
+
+function fillModules(startDigit) {
+  return MODULE_KEYS.reduce((acc, key, index) => {
+    const digit = ((parseInt(startDigit, 16) + index) % 16).toString(16);
+    acc[key] = addressOf(digit);
+    return acc;
+  }, {});
+}
+
+describe('job-registry-config-console library', () => {
+  it('parses console arguments with action detection and overrides', () => {
+    const argv = [
+      'node',
+      'script.js',
+      '--from',
+      '0x1234567890abcdef1234567890abcdef12345678',
+      '--execute=false',
+      '--timings.commitWindow',
+      '7200',
+      'update',
+    ];
+
+    const parsed = parseConfigConsoleArgs(argv);
+    expect(parsed.action).to.equal(ACTIONS.UPDATE);
+    expect(parsed.from).to.equal('0x1234567890abcdef1234567890abcdef12345678');
+    expect(parsed.execute).to.be.false;
+    expect(parsed.timings.commitWindow).to.equal('7200');
+  });
+
+  it('builds set plans using overrides and defaults', () => {
+    const currentModules = fillModules('1');
+    const overrides = {
+      modules: { ...MODULE_KEYS.reduce((acc, key) => ((acc[key] = undefined), acc), {}), identity: addressOf('a') },
+      timings: { commitWindow: '9000' },
+      thresholds: { feeBps: '300' },
+    };
+    const defaults = {
+      modules: fillModules('2'),
+      timings: { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 },
+      thresholds: {
+        approvalThresholdBps: 6000,
+        quorumMin: 3,
+        quorumMax: 11,
+        feeBps: 250,
+        slashBpsMax: 2000,
+      },
+    };
+
+    const plans = buildSetPlans({
+      currentModules,
+      currentTimings: { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 },
+      currentThresholds: {
+        approvalThresholdBps: 6000,
+        quorumMin: 3,
+        quorumMax: 11,
+        feeBps: 250,
+        slashBpsMax: 2000,
+      },
+      overrides,
+      defaults,
+    });
+
+    expect(plans.modulesPlan.changed).to.be.true;
+    expect(plans.modulesPlan.desired.identity).to.equal(addressOf('a'));
+    expect(plans.timingsPlan.desired.commitWindow).to.equal(9000);
+    expect(plans.thresholdsPlan.desired.feeBps).to.equal(300);
+  });
+
+  it('builds module update plan with normalization and diff reporting', () => {
+    const overrides = {
+      modules: { identity: addressOf('b') },
+      timings: {},
+      thresholds: {},
+    };
+    const plan = buildUpdatePlan({
+      overrides,
+      currentModules: fillModules('1'),
+      currentTimings: {},
+      currentThresholds: {
+        approvalThresholdBps: 6000,
+        quorumMin: 3,
+        quorumMax: 11,
+        feeBps: 250,
+        slashBpsMax: 2000,
+      },
+    });
+
+    expect(plan.method).to.equal('updateModule');
+    expect(plan.args[0]).to.equal(MODULE_ENUM.identity);
+    expect(plan.summary.next).to.equal(addressOf('b'));
+  });
+
+  it('builds timing update plan enforcing positive integers', () => {
+    const overrides = {
+      modules: {},
+      timings: { revealWindow: '5400' },
+      thresholds: {},
+    };
+
+    const plan = buildUpdatePlan({
+      overrides,
+      currentModules: fillModules('1'),
+      currentTimings: { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 },
+      currentThresholds: {
+        approvalThresholdBps: 6000,
+        quorumMin: 3,
+        quorumMax: 11,
+        feeBps: 250,
+        slashBpsMax: 2000,
+      },
+    });
+
+    expect(plan.method).to.equal('updateTiming');
+    expect(plan.args[0]).to.equal(TIMING_ENUM.revealWindow);
+    expect(plan.summary.next).to.equal(5400);
+  });
+
+  it('builds threshold update plan with BPS validation', () => {
+    const overrides = {
+      modules: {},
+      timings: {},
+      thresholds: { feeBps: String(BPS_DENOMINATOR) },
+    };
+
+    const plan = buildUpdatePlan({
+      overrides,
+      currentModules: fillModules('1'),
+      currentTimings: { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 },
+      currentThresholds: {
+        approvalThresholdBps: 6000,
+        quorumMin: 3,
+        quorumMax: 11,
+        feeBps: 250,
+        slashBpsMax: 2000,
+      },
+    });
+
+    expect(plan.method).to.equal('updateThreshold');
+    expect(plan.args[0]).to.equal(THRESHOLD_ENUM.feeBps);
+    expect(plan.summary.next).to.equal(BPS_DENOMINATOR);
+  });
+
+  it('rejects multiple overrides for update action', () => {
+    const overrides = {
+      modules: { identity: addressOf('a') },
+      timings: { commitWindow: '7200' },
+      thresholds: {},
+    };
+
+    expect(() =>
+      buildUpdatePlan({
+        overrides,
+        currentModules: fillModules('1'),
+        currentTimings: { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 },
+        currentThresholds: {
+          approvalThresholdBps: 6000,
+          quorumMin: 3,
+          quorumMax: 11,
+          feeBps: 250,
+          slashBpsMax: 2000,
+        },
+      })
+    ).to.throw('Update action accepts only one override');
+  });
+
+  it('rejects quorumMin values above quorumMax', () => {
+    const overrides = {
+      modules: {},
+      timings: {},
+      thresholds: { quorumMin: '12' },
+    };
+
+    expect(() =>
+      buildUpdatePlan({
+        overrides,
+        currentModules: fillModules('1'),
+        currentTimings: { commitWindow: 3600, revealWindow: 3600, disputeWindow: 7200 },
+        currentThresholds: {
+          approvalThresholdBps: 6000,
+          quorumMin: 3,
+          quorumMax: 11,
+          feeBps: 250,
+          slashBpsMax: 2000,
+        },
+      })
+    ).to.throw('thresholds.quorumMin (12) must not exceed the current quorumMax (11)');
+  });
+});


### PR DESCRIPTION
## Summary
- factor shared configuration utilities and module default resolution helpers
- add a job-registry configuration console supporting status, set, and single-field update flows for operators
- document the console, expose an npm script, and cover the planning library with targeted unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d18dd3d65c8333801abb98199d2ba8