### PR TITLE
Add interactive parameter editor and extend CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: Validate configuration guardrails
+        run: npm run config:validate
+      - name: Dry-run parameter editor to confirm defaults
+        run: npm run config:params -- --no-interactive --dry-run
       - run: npm run lint:sol
       - run: npm run test
       - run: npm run coverage

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Edit configuration files under `config/` to match the deployment environment:
 - `config/ens.dev.json` / `config/ens.sepolia.json` / `config/ens.mainnet.json` — ENS registry and subdomain roots (refresh
   `npm run namehash -- <variant>` or `node scripts/compute-namehash.js <path-to-config>`; the variant command defaults to
   `mainnet`).
-- `config/params.json` — Commit/reveal/dispute windows and governance thresholds.
+- `config/params.json` — Commit/reveal/dispute windows and governance thresholds. Run
+  `npm run config:params` for an interactive editor that validates ranges, highlights
+  changes, and writes the updated JSON back to disk. Non-interactive environments can
+  provide explicit overrides via `npm run config:params -- --no-interactive --set feeBps=300 --yes`.
 - Run `npm run config:validate` after editing to confirm addresses, namehashes, and governance parameters satisfy production
   guardrails before broadcasting migrations.
 
@@ -61,6 +64,7 @@ Edit configuration files under `config/` to match the deployment environment:
 
   timings, and governance thresholds against the repository defaults. The summary highlights any drift and prints the sender,
   owner, and params profile so operators can confirm the context before acting.
+
 - Pass `-- --execute --from 0xYourOwnerAddress` to broadcast updates from an authorized account. The helper automatically
   repopulates missing module addresses from local deployments, applies overrides provided via CLI flags (for example,
   `--modules.identity` or `--thresholds.feeBps`), and validates all numerical constraints before submitting transactions.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "namehash:dev": "node scripts/compute-namehash.js dev",
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",
     "config:validate": "node scripts/validate-config.js",
+    "config:params": "node scripts/edit-params.js",
     "prepare": "husky install",
     "hardhat:test": "node scripts/run-tests.js",
     "config:console": "npx truffle exec scripts/job-registry-config-console.js --network ${NETWORK:-development}"

--- a/scripts/edit-params.js
+++ b/scripts/edit-params.js
@@ -1,0 +1,379 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const DEFAULT_PARAMS_PATH = path.join(__dirname, '..', 'config', 'params.json');
+
+const PARAM_DEFINITIONS = [
+  {
+    key: 'commitWindow',
+    label: 'Commit window (seconds)',
+    description: 'Time allowed for workers to commit job results before revealing.',
+    minimum: 60,
+    maximum: null,
+  },
+  {
+    key: 'revealWindow',
+    label: 'Reveal window (seconds)',
+    description:
+      'Duration for workers to reveal commitments. Should be shorter than the commit window.',
+    minimum: 60,
+    maximum: null,
+  },
+  {
+    key: 'disputeWindow',
+    label: 'Dispute window (seconds)',
+    description: 'Period during which disputes can be raised after reveal.',
+    minimum: 60,
+    maximum: null,
+  },
+  {
+    key: 'approvalThresholdBps',
+    label: 'Approval threshold (basis points)',
+    description: 'Percentage of approvals required (out of 10,000).',
+    minimum: 0,
+    maximum: 10000,
+  },
+  {
+    key: 'quorumMin',
+    label: 'Minimum quorum',
+    description: 'Minimum number of reviewers required.',
+    minimum: 1,
+    maximum: null,
+  },
+  {
+    key: 'quorumMax',
+    label: 'Maximum quorum',
+    description: 'Maximum number of reviewers that can participate.',
+    minimum: 1,
+    maximum: null,
+  },
+  {
+    key: 'feeBps',
+    label: 'Protocol fee (basis points)',
+    description: 'Fee retained by the protocol per job (out of 10,000).',
+    minimum: 0,
+    maximum: 10000,
+  },
+  {
+    key: 'slashBpsMax',
+    label: 'Maximum slash (basis points)',
+    description: 'Maximum percentage of stake that can be slashed per dispute.',
+    minimum: 0,
+    maximum: 10000,
+  },
+];
+
+function parseArgs(argv) {
+  const args = {
+    file: DEFAULT_PARAMS_PATH,
+    set: {},
+    dryRun: false,
+    yes: false,
+    help: false,
+    interactive: null,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const current = argv[i];
+
+    if (current === '--help' || current === '-h') {
+      args.help = true;
+      continue;
+    }
+
+    if (current === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+
+    if (current === '--yes' || current === '--force') {
+      args.yes = true;
+      continue;
+    }
+
+    if (current === '--file') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error('--file requires a path argument');
+      }
+      args.file = path.resolve(next);
+      i += 1;
+      continue;
+    }
+
+    if (current === '--interactive') {
+      args.interactive = true;
+      continue;
+    }
+
+    if (current === '--no-interactive') {
+      args.interactive = false;
+      continue;
+    }
+
+    if (current.startsWith('--set')) {
+      const [, valuePart] = current.split('=');
+      let assignment = valuePart;
+      if (!assignment) {
+        const next = argv[i + 1];
+        if (!next || next.startsWith('--')) {
+          throw new Error('--set requires key=value');
+        }
+        assignment = next;
+        i += 1;
+      }
+
+      const [key, value] = assignment.split('=');
+      if (!key || value === undefined) {
+        throw new Error(`Invalid --set assignment "${assignment}". Expected key=value.`);
+      }
+      args.set[key] = value;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${current}`);
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log('AGIJobsv1 — params editor');
+  console.log('Usage: node scripts/edit-params.js [options]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --file <path>         Path to params JSON (defaults to config/params.json)');
+  console.log('  --set key=value       Override a parameter without prompting (repeatable)');
+  console.log('  --dry-run             Print resulting JSON without writing to disk');
+  console.log('  --yes                 Skip the confirmation prompt and accept changes');
+  console.log('  --interactive         Force interactive prompts even when using --set');
+  console.log('  --no-interactive      Disable prompts; only apply explicit --set overrides');
+  console.log('  --help                Display this help message');
+}
+
+function loadParams(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Params file not found at ${resolvedPath}`);
+  }
+
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    throw new Error(`Unable to parse JSON at ${resolvedPath}: ${error.message}`);
+  }
+}
+
+function coerceNumber(value, key) {
+  if (value === '' || value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value.trim());
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid numeric value for ${key}: ${value}`);
+    }
+    return parsed;
+  }
+
+  throw new Error(`Invalid value for ${key}: ${value}`);
+}
+
+function validateParams(candidate) {
+  const errors = [];
+
+  PARAM_DEFINITIONS.forEach((definition) => {
+    const value = candidate[definition.key];
+
+    if (value === undefined) {
+      errors.push(`Missing value for ${definition.key}.`);
+      return;
+    }
+
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      errors.push(`Value for ${definition.key} must be a finite number.`);
+      return;
+    }
+
+    if (!Number.isInteger(value)) {
+      errors.push(`Value for ${definition.key} must be an integer.`);
+      return;
+    }
+
+    if (definition.minimum !== null && value < definition.minimum) {
+      errors.push(`${definition.key} must be greater than or equal to ${definition.minimum}.`);
+    }
+
+    if (definition.maximum !== null && value > definition.maximum) {
+      errors.push(`${definition.key} must be less than or equal to ${definition.maximum}.`);
+    }
+  });
+
+  const { quorumMin, quorumMax } = candidate;
+  if (
+    typeof quorumMin === 'number' &&
+    typeof quorumMax === 'number' &&
+    Number.isFinite(quorumMin) &&
+    Number.isFinite(quorumMax) &&
+    quorumMin > quorumMax
+  ) {
+    errors.push('quorumMin must be less than or equal to quorumMax.');
+  }
+
+  const { approvalThresholdBps } = candidate;
+  if (typeof approvalThresholdBps === 'number' && Number.isFinite(approvalThresholdBps)) {
+    const quorumFloor = quorumMin || 0;
+    if (approvalThresholdBps > 0 && quorumFloor === 0) {
+      errors.push('approvalThresholdBps > 0 requires quorumMin to be at least 1.');
+    }
+  }
+
+  return errors;
+}
+
+async function promptUser(definition, currentValue, rl) {
+  const questionParts = [
+    `${definition.label}`,
+    `Current value: ${currentValue}`,
+    definition.description ? definition.description : null,
+    definition.minimum !== null ? `Minimum: ${definition.minimum}` : null,
+    definition.maximum !== null ? `Maximum: ${definition.maximum}` : null,
+  ].filter(Boolean);
+
+  const prompt = `${questionParts.join('\n')}\n> `;
+
+  const answer = await new Promise((resolve) => {
+    rl.question(prompt, (response) => {
+      resolve(response.trim());
+    });
+  });
+
+  if (answer === '') {
+    return currentValue;
+  }
+
+  return coerceNumber(answer, definition.key);
+}
+
+async function collectParams(baseValues, overrides, interactive) {
+  const nextValues = { ...baseValues };
+
+  Object.entries(overrides).forEach(([key, rawValue]) => {
+    const definition = PARAM_DEFINITIONS.find((entry) => entry.key === key);
+    if (!definition) {
+      throw new Error(`Unknown parameter in --set: ${key}`);
+    }
+    nextValues[key] = coerceNumber(rawValue, key);
+  });
+
+  if (!interactive) {
+    return nextValues;
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  try {
+    for (const definition of PARAM_DEFINITIONS) {
+      if (overrides.hasOwnProperty(definition.key)) {
+        continue;
+      }
+
+      const updated = await promptUser(definition, nextValues[definition.key], rl);
+      nextValues[definition.key] = updated;
+    }
+  } finally {
+    rl.close();
+  }
+
+  return nextValues;
+}
+
+function formatSummary(previous, next) {
+  const lines = [];
+  PARAM_DEFINITIONS.forEach((definition) => {
+    const before = previous[definition.key];
+    const after = next[definition.key];
+    const changed = before !== after;
+    const indicator = changed ? '•' : ' ';
+    lines.push(`${indicator} ${definition.key}: ${before} → ${after}`);
+  });
+  return lines.join('\n');
+}
+
+async function confirm(message) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await new Promise((resolve) => {
+      rl.question(`${message} (y/N) `, (response) => {
+        resolve(response.trim().toLowerCase());
+      });
+    });
+
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const currentValues = loadParams(args.file);
+
+  const hasOverrides = Object.keys(args.set).length > 0;
+  const interactiveCandidate =
+    args.interactive !== null
+      ? args.interactive
+      : !hasOverrides && process.stdin.isTTY && process.stdout.isTTY;
+  const interactive = Boolean(interactiveCandidate);
+  const nextValues = await collectParams(currentValues, args.set, interactive);
+
+  const validationErrors = validateParams(nextValues);
+  if (validationErrors.length > 0) {
+    validationErrors.forEach((error) => console.error(`✖ ${error}`));
+    throw new Error('Aborting due to validation errors.');
+  }
+
+  const summary = formatSummary(currentValues, nextValues);
+  console.log('\nProposed parameter set:\n');
+  console.log(summary);
+  console.log('');
+
+  if (args.dryRun) {
+    console.log('Dry run enabled — not writing to disk.');
+    console.log(JSON.stringify(nextValues, null, 2));
+    return;
+  }
+
+  if (!args.yes) {
+    const accepted = await confirm('Write changes to file?');
+    if (!accepted) {
+      console.log('Aborted by user — no changes written.');
+      return;
+    }
+  }
+
+  const serialized = `${JSON.stringify(nextValues, null, 2)}\n`;
+  fs.writeFileSync(args.file, serialized, 'utf8');
+  console.log(`Saved parameters to ${args.file}`);
+}
+
+main().catch((error) => {
+  console.error(`Error: ${error.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a guided `config:params` CLI that validates lifecycle and economic thresholds before writing updates
- document the new workflow for operators and make it accessible via an npm script
- extend CI to run configuration validation and dry-run the parameter editor on every build alongside the existing checks

## Testing
- npm test
- node scripts/edit-params.js --dry-run --no-interactive

------
https://chatgpt.com/codex/tasks/task_e_68d191a40abc83339837dc142152e594