### PR TITLE
Harden Echidna install and add identity console tests

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -32,12 +32,18 @@ jobs:
               *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
             esac
 
+            if ! command -v jq >/dev/null 2>&1; then
+              sudo apt-get install -y jq
+            fi
+
             tmpdir=$(mktemp -d)
-            asset_url=$(curl -fsSL https://api.github.com/repos/crytic/echidna/releases/latest \
-              | grep browser_download_url \
-              | grep "$asset_arch" \
-              | head -n 1 \
-              | cut -d '"' -f 4)
+            curl_args=(-fsSL "-H" "Accept: application/vnd.github+json" "-H" "X-GitHub-Api-Version: 2022-11-28")
+            if [ -n "${GITHUB_TOKEN:-}" ]; then
+              curl_args+=("-H" "Authorization: Bearer ${GITHUB_TOKEN}")
+            fi
+            asset_url=$(curl "${curl_args[@]}" https://api.github.com/repos/crytic/echidna/releases/latest \
+              | jq -r --arg arch "$asset_arch" '.assets[] | select(.browser_download_url | contains($arch)) | .browser_download_url' \
+              | head -n 1)
             if [ -z "$asset_url" ]; then
               echo "Unable to locate Echidna release asset for $asset_arch" >&2
               exit 1
@@ -85,12 +91,18 @@ jobs:
               *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
             esac
 
+            if ! command -v jq >/dev/null 2>&1; then
+              sudo apt-get install -y jq
+            fi
+
             tmpdir=$(mktemp -d)
-            asset_url=$(curl -fsSL https://api.github.com/repos/crytic/echidna/releases/latest \
-              | grep browser_download_url \
-              | grep "$asset_arch" \
-              | head -n 1 \
-              | cut -d '"' -f 4)
+            curl_args=(-fsSL "-H" "Accept: application/vnd.github+json" "-H" "X-GitHub-Api-Version: 2022-11-28")
+            if [ -n "${GITHUB_TOKEN:-}" ]; then
+              curl_args+=("-H" "Authorization: Bearer ${GITHUB_TOKEN}")
+            fi
+            asset_url=$(curl "${curl_args[@]}" https://api.github.com/repos/crytic/echidna/releases/latest \
+              | jq -r --arg arch "$asset_arch" '.assets[] | select(.browser_download_url | contains($arch)) | .browser_download_url' \
+              | head -n 1)
             if [ -z "$asset_url" ]; then
               echo "Unable to locate Echidna release asset for $asset_arch" >&2
               exit 1

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Edit configuration files under `config/` to match the deployment environment:
 - `extend`, `finalize`, `timeout`, and `resolve` commands enforce the same invariants as the contracts (quorum bounds,
   slashing ceilings, lifecycle states) so non-technical operators receive human-readable error messages before risking gas.
 
+### IdentityRegistry ENS console
+
+- Run `npm run identity:console -- --network <network> status` for a snapshot of the on-chain ENS wiring, including
+  registry and wrapper addresses, root hashes, and the `alphaEnabled` flag.
+- Use the `set` action to align the on-chain configuration with repository defaults from `config/ens.<variant>.json` and
+  any CLI overrides, for example `npm run identity:console -- --network mainnet set --execute --ens.alphaEnabled true`.
+- Dry runs print the Safe-ready payload (`to`, `data`, and argument list) so owners can forward transactions through a
+  multisig or custom signing flow before toggling `--execute`.
+- CLI overrides accept ENS names (`--ens.agentRoot`) or pre-computed hashes (`--ens.agentRootHash`), making it simple to
+  flip `alphaEnabled` with the correct root hash without editing JSON by hand.
+
 ### Alpha Club activation
 
 Premium `alpha.club.agi.eth` identities ship pre-configured in `config/ens.*.json`. The registrar enforces the 5,000 `$AGIALPHA` price floor automatically, so only funded registrations can mint these labels. `config/registrar.mainnet.json` now fixes both the minimum and maximum `alpha` label price at exactly 5,000 tokens, and `npm run registrar:verify` fails if the deployed `ForeverSubdomainRegistrar` drifts above that ceiling. Governance controls whether the `IdentityRegistry` marks the alpha namespace as officially active via the `alphaEnabled` flag that `configureEns` manages.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "namehash:mainnet": "node scripts/compute-namehash.js mainnet",
     "config:validate": "node scripts/validate-config.js",
     "config:params": "node scripts/edit-params.js",
+    "identity:console": "npx truffle exec scripts/identity-registry-console.js --network ${NETWORK:-development}",
     "prepare": "husky install",
     "hardhat:test": "node scripts/run-tests.js",
     "config:console": "npx truffle exec scripts/job-registry-config-console.js --network ${NETWORK:-development}"

--- a/scripts/identity-registry-console.js
+++ b/scripts/identity-registry-console.js
@@ -1,0 +1,182 @@
+const IdentityRegistry = artifacts.require('IdentityRegistry');
+
+const {
+  ACTIONS,
+  parseIdentityConsoleArgs,
+  loadEnsConfig,
+  buildSetPlan,
+  formatStatusLines,
+  formatPlanLines,
+  collectCurrentConfig,
+} = require('./lib/identity-registry-console');
+const { extractNetwork, toChecksum } = require('./lib/job-registry-config-utils');
+const { resolveVariant } = require('./config-loader');
+
+function printHelp() {
+  console.log('AGI Jobs v1 — IdentityRegistry ENS console');
+  console.log('Usage: npx truffle exec scripts/identity-registry-console.js --network <network> [action] [options]');
+  console.log('');
+  console.log('Actions:');
+  console.log('  status   Display current on-chain configuration (default)');
+  console.log('  set      Align on-chain configuration with config files and optional overrides');
+  console.log('');
+  console.log('Common options:');
+  console.log('  --from <address>         Sender address (defaults to first unlocked account)');
+  console.log('  --execute[=true|false]  Broadcast transaction instead of dry run');
+  console.log('  --dry-run[=true|false]  Alias for --execute');
+  console.log('  --variant <name>        Optional config variant hint');
+  console.log('  --config <path>         Explicit ENS config file path');
+  console.log('  --help                  Show this message');
+  console.log('');
+  console.log('ENS overrides (applied on top of config file values):');
+  console.log('  --ens.registry <address>');
+  console.log('  --ens.nameWrapper <address>');
+  console.log('  --ens.agentRoot <ens name> | --ens.agentRootHash <bytes32>');
+  console.log('  --ens.clubRoot <ens name>  | --ens.clubRootHash <bytes32>');
+  console.log('  --ens.alphaClubRoot <ens name> | --ens.alphaClubRootHash <bytes32>');
+  console.log('  --ens.alphaEnabled[=true|false]');
+}
+
+module.exports = async function (callback) {
+  try {
+    const options = parseIdentityConsoleArgs(process.argv);
+    if (options.help) {
+      printHelp();
+      callback();
+      return;
+    }
+
+    const action = options.action || ACTIONS.STATUS;
+    if (!Object.values(ACTIONS).includes(action)) {
+      throw new Error(`Unsupported action "${options.action}". Use status or set.`);
+    }
+
+    const networkName =
+      extractNetwork(process.argv) || process.env.NETWORK || process.env.TRUFFLE_NETWORK || null;
+
+    let resolvedVariant = null;
+    try {
+      resolvedVariant = resolveVariant(options.variant || networkName || undefined);
+    } catch (error) {
+      console.warn(
+        `Warning: unable to resolve variant for "${options.variant || networkName || '(unspecified)'}": ${error.message}`
+      );
+    }
+
+    const identity = await IdentityRegistry.deployed();
+    const identityAddress = toChecksum(identity.address);
+    const owner = toChecksum(await identity.owner());
+
+    if (options.from && !web3.utils.isAddress(options.from)) {
+      throw new Error(`Invalid --from address: ${options.from}`);
+    }
+
+    const accounts = await web3.eth.getAccounts();
+    const sender = options.from
+      ? toChecksum(options.from)
+      : accounts[0]
+        ? toChecksum(accounts[0])
+        : null;
+
+    if (!sender) {
+      throw new Error('No sender account is available. Specify --from explicitly.');
+    }
+
+    const current = await collectCurrentConfig(identity);
+
+    console.log('AGIJobsv1 — IdentityRegistry ENS console');
+    console.log(`Action: ${action}`);
+    console.log(
+      `Network: ${networkName || '(unspecified)'}${resolvedVariant ? ` (variant: ${resolvedVariant})` : ''}`
+    );
+    console.log(`IdentityRegistry: ${identityAddress}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log(`Sender: ${sender}`);
+    console.log('');
+
+    formatStatusLines(current).forEach((line) => console.log(line));
+    console.log('');
+
+    const variantForConfig = resolvedVariant || options.variant || networkName || undefined;
+
+    if (action === ACTIONS.STATUS) {
+      if (options.overrides && Object.keys(options.overrides).length > 0) {
+        console.log('Overrides provided during status action are ignored.');
+        console.log('');
+      }
+
+      if (options.configPath || variantForConfig) {
+        try {
+          const configProfile = loadEnsConfig({
+            explicitPath: options.configPath,
+            variant: variantForConfig,
+          });
+          console.log(`Config file: ${configProfile.path}`);
+          const plan = buildSetPlan({ current, baseConfig: configProfile.values, overrides: {} });
+          if (plan.changed) {
+            console.log('');
+            formatPlanLines(plan).forEach((line) => console.log(line));
+          } else {
+            console.log('\nOn-chain configuration already matches the desired profile.');
+          }
+        } catch (error) {
+          console.warn(`Warning: unable to evaluate config drift: ${error.message}`);
+        }
+      }
+
+      callback();
+      return;
+    }
+
+    const shouldExecute = Boolean(options.execute);
+    const configProfile = loadEnsConfig({
+      explicitPath: options.configPath,
+      variant: variantForConfig,
+    });
+
+    console.log(`Config file: ${configProfile.path}`);
+
+    const plan = buildSetPlan({ current, baseConfig: configProfile.values, overrides: options.overrides });
+
+    console.log('');
+    formatPlanLines(plan).forEach((line) => console.log(line));
+
+    if (!plan.changed) {
+      console.log('\nOn-chain configuration already matches the desired profile.');
+      callback();
+      return;
+    }
+
+    const callData = identity.contract.methods.configureEns(...plan.args).encodeABI();
+
+    if (!shouldExecute) {
+      console.log('\nDry run: transaction not broadcast.');
+      console.log(
+        JSON.stringify(
+          {
+            to: identity.address,
+            from: sender,
+            data: callData,
+            value: '0',
+            description: 'IdentityRegistry.configureEns',
+            arguments: plan.args,
+          },
+          null,
+          2
+        )
+      );
+      callback();
+      return;
+    }
+
+    if (!owner || owner.toLowerCase() !== sender.toLowerCase()) {
+      throw new Error(`Sender ${sender} is not the IdentityRegistry owner (${owner}).`);
+    }
+
+    const receipt = await identity.configureEns(...plan.args, { from: sender });
+    console.log(`\nTransaction broadcast. Hash: ${receipt.tx}`);
+    callback();
+  } catch (error) {
+    callback(error);
+  }
+};

--- a/scripts/lib/identity-registry-console.js
+++ b/scripts/lib/identity-registry-console.js
@@ -1,0 +1,445 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { hash: computeNamehash, normalize: normalizeEnsName } = require('eth-ens-namehash');
+
+const { configPath, readConfig, resolveVariant } = require('../config-loader');
+const { toChecksum, formatDiffEntry } = require('./job-registry-config-utils');
+
+const ACTIONS = Object.freeze({
+  STATUS: 'status',
+  SET: 'set',
+});
+
+const HEX_32_REGEX = /^0x[0-9a-fA-F]{64}$/;
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ZERO_BYTES32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+function parseBooleanFlag(value, defaultValue = false) {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (['1', 'true', 't', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'f', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  throw new Error(`Unable to parse boolean flag from "${value}"`);
+}
+
+function normalizeKey(key) {
+  return key.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function parseIdentityConsoleArgs(argv) {
+  const result = {
+    action: ACTIONS.STATUS,
+    execute: false,
+    from: null,
+    configPath: null,
+    variant: null,
+    overrides: {},
+    help: false,
+  };
+
+  const assignOption = (key, rawValue) => {
+    const value = rawValue === undefined ? true : rawValue;
+    switch (key) {
+      case 'help':
+        result.help = true;
+        return;
+      case 'execute':
+        result.execute = parseBooleanFlag(value, true);
+        return;
+      case 'dry-run':
+        result.execute = !parseBooleanFlag(value, true);
+        return;
+      case 'from':
+        if (value && typeof value === 'string') {
+          result.from = value;
+        }
+        return;
+      case 'config':
+      case 'config-path':
+        if (!value) {
+          throw new Error('--config requires a path argument');
+        }
+        result.configPath = value;
+        return;
+      case 'variant':
+        if (value && typeof value === 'string') {
+          result.variant = value;
+        }
+        return;
+      default:
+        if (key.startsWith('ens.')) {
+          const subKey = normalizeKey(key.slice(4));
+          if (!subKey) {
+            throw new Error(`Unrecognized ENS override flag "${key}"`);
+          }
+          result.overrides[subKey] = value;
+        }
+    }
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (typeof arg !== 'string') {
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      const trimmed = arg.slice(2);
+      if (trimmed.includes('=')) {
+        const [key, rawValue] = trimmed.split(/=(.+)/);
+        assignOption(key, rawValue);
+      } else {
+        const next = argv[i + 1];
+        if (next === undefined || (typeof next === 'string' && next.startsWith('--'))) {
+          assignOption(trimmed);
+        } else {
+          assignOption(trimmed, next);
+          i += 1;
+        }
+      }
+      continue;
+    }
+
+    if (!result.action || result.action === ACTIONS.STATUS) {
+      const candidate = arg.toLowerCase();
+      if (candidate === ACTIONS.STATUS || candidate === ACTIONS.SET) {
+        result.action = candidate;
+        continue;
+      }
+    }
+  }
+
+  return result;
+}
+
+function loadEnsConfig({ explicitPath, variant }) {
+  if (explicitPath) {
+    const resolvedPath = path.resolve(process.cwd(), explicitPath);
+    const raw = fs.readFileSync(resolvedPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return { path: resolvedPath, variant: null, values: parsed };
+  }
+
+  const resolvedVariant = resolveVariant(variant);
+  const configFilePath = configPath('ens', resolvedVariant);
+  const values = readConfig('ens', resolvedVariant);
+  return { path: configFilePath, variant: resolvedVariant, values };
+}
+
+function ensureAddress(value, label) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const candidate = String(value).trim();
+  if (!ADDRESS_REGEX.test(candidate)) {
+    throw new Error(`${label} must be a valid 0x-prefixed address`);
+  }
+
+  return candidate;
+}
+
+function ensureHash(value, label) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const candidate = String(value).trim();
+  if (!HEX_32_REGEX.test(candidate)) {
+    throw new Error(`${label} must be a 32-byte hex string`);
+  }
+
+  return `0x${candidate.slice(2).toLowerCase()}`;
+}
+
+function normalizeAddressForCompare(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const candidate = String(value).trim();
+  if (candidate.length === 0) {
+    return null;
+  }
+
+  if (candidate.toLowerCase() === ZERO_ADDRESS) {
+    return null;
+  }
+
+  return candidate.toLowerCase();
+}
+
+function formatAddressOrUnset(value) {
+  if (!value) {
+    return '(unset)';
+  }
+  const candidate = String(value);
+  if (candidate.toLowerCase() === ZERO_ADDRESS) {
+    return '(unset)';
+  }
+  const checksum = toChecksum(candidate);
+  return checksum || candidate;
+}
+
+function ensureEnsHashFromName(value, label) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const candidate = String(value).trim();
+  if (candidate.length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+
+  try {
+    const normalized = normalizeEnsName(candidate);
+    return computeNamehash(normalized);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    throw new Error(`Invalid ENS name for ${label}: ${message}`);
+  }
+}
+
+function deriveDesiredConfig(baseValues, overrides = {}) {
+  const desired = {
+    registry: ensureAddress(baseValues.registry, 'registry'),
+    nameWrapper: ensureAddress(baseValues.nameWrapper, 'nameWrapper'),
+    agentRootHash:
+      ensureHash(baseValues.agentRootHash, 'agentRootHash') ||
+      ensureEnsHashFromName(baseValues.agentRoot, 'agentRoot'),
+    clubRootHash:
+      ensureHash(baseValues.clubRootHash, 'clubRootHash') ||
+      ensureEnsHashFromName(baseValues.clubRoot, 'clubRoot'),
+    alphaClubRootHash:
+      ensureHash(baseValues.alphaClubRootHash, 'alphaClubRootHash') ||
+      ensureEnsHashFromName(baseValues.alphaClubRoot, 'alphaClubRoot'),
+    alphaEnabled:
+      baseValues.alphaEnabled === undefined ? false : Boolean(baseValues.alphaEnabled),
+  };
+
+  const applyOverride = (key, rawValue) => {
+    if (rawValue === undefined || rawValue === null) {
+      return;
+    }
+
+    switch (key) {
+      case 'registry':
+        desired.registry = ensureAddress(rawValue, 'ens.registry');
+        break;
+      case 'nameWrapper':
+      case 'name-wrapper':
+        desired.nameWrapper = ensureAddress(rawValue, 'ens.nameWrapper');
+        break;
+      case 'agentRootHash':
+      case 'agent-root-hash':
+        desired.agentRootHash = ensureHash(rawValue, 'ens.agentRootHash');
+        break;
+      case 'clubRootHash':
+      case 'club-root-hash':
+        desired.clubRootHash = ensureHash(rawValue, 'ens.clubRootHash');
+        break;
+      case 'alphaClubRootHash':
+      case 'alpha-club-root-hash':
+        desired.alphaClubRootHash = ensureHash(rawValue, 'ens.alphaClubRootHash');
+        break;
+      case 'agentRoot':
+      case 'agent-root':
+        desired.agentRootHash = ensureEnsHashFromName(rawValue, 'ens.agentRoot');
+        break;
+      case 'clubRoot':
+      case 'club-root':
+        desired.clubRootHash = ensureEnsHashFromName(rawValue, 'ens.clubRoot');
+        break;
+      case 'alphaClubRoot':
+      case 'alpha-club-root':
+        desired.alphaClubRootHash = ensureEnsHashFromName(rawValue, 'ens.alphaClubRoot');
+        break;
+      case 'alphaEnabled':
+      case 'alpha-enabled':
+        desired.alphaEnabled = parseBooleanFlag(rawValue, true);
+        break;
+      default:
+        break;
+    }
+  };
+
+  Object.entries(overrides).forEach(([key, value]) => applyOverride(key, value));
+
+  if (!desired.registry || desired.registry === ZERO_ADDRESS) {
+    throw new Error('IdentityRegistry.configureEns requires a non-zero registry address');
+  }
+  if (!desired.agentRootHash) {
+    throw new Error('IdentityRegistry.configureEns requires agentRootHash to be set');
+  }
+  if (!desired.clubRootHash) {
+    throw new Error('IdentityRegistry.configureEns requires clubRootHash to be set');
+  }
+  if (desired.alphaEnabled && (!desired.alphaClubRootHash || desired.alphaClubRootHash === ZERO_ADDRESS)) {
+    throw new Error('alphaEnabled=true requires alphaClubRootHash to be non-zero');
+  }
+
+  return desired;
+}
+
+function normalizeHashForCompare(value) {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const candidate = String(value).trim().toLowerCase();
+  if (candidate === ZERO_BYTES32) {
+    return null;
+  }
+
+  if (!HEX_32_REGEX.test(candidate)) {
+    return candidate;
+  }
+
+  return candidate;
+}
+
+function formatHashOrUnset(value) {
+  if (!value) {
+    return '(unset)';
+  }
+  const candidate = String(value);
+  return candidate.toLowerCase() === ZERO_BYTES32 ? '(unset)' : candidate;
+}
+
+function computeSetDiff(current, desired) {
+  const diff = {};
+
+  const compareAddress = (key, next) => {
+    const previousNormalized = normalizeAddressForCompare(current[key]);
+    const nextNormalized = normalizeAddressForCompare(next);
+    if ((previousNormalized || null) !== (nextNormalized || null)) {
+      diff[key] = { previous: current[key] || null, next };
+    }
+  };
+
+  const compareHash = (key, next) => {
+    const previousNormalized = normalizeHashForCompare(current[key]);
+    const nextNormalized = normalizeHashForCompare(next);
+    if ((previousNormalized || null) !== (nextNormalized || null)) {
+      diff[key] = { previous: current[key] || null, next };
+    }
+  };
+
+  const compareBoolean = (key, next) => {
+    const previous = Boolean(current[key]);
+    if (previous !== Boolean(next)) {
+      diff[key] = { previous, next: Boolean(next) };
+    }
+  };
+
+  compareAddress('registry', desired.registry);
+  compareAddress('nameWrapper', desired.nameWrapper);
+  compareHash('agentRootHash', desired.agentRootHash);
+  compareHash('clubRootHash', desired.clubRootHash);
+  compareHash('alphaClubRootHash', desired.alphaClubRootHash);
+  compareBoolean('alphaEnabled', desired.alphaEnabled);
+
+  return diff;
+}
+
+function buildSetPlan({ current, baseConfig, overrides }) {
+  const desired = deriveDesiredConfig(baseConfig, overrides);
+  const diff = computeSetDiff(current, desired);
+  const changed = Object.keys(diff).length > 0;
+
+  const args = [
+    desired.registry,
+    desired.nameWrapper || ZERO_ADDRESS,
+    desired.agentRootHash,
+    desired.clubRootHash,
+    desired.alphaClubRootHash || ZERO_ADDRESS,
+    Boolean(desired.alphaEnabled),
+  ];
+
+  return {
+    desired,
+    diff,
+    changed,
+    args,
+  };
+}
+
+function formatStatusLines(current) {
+  return [
+    'On-chain IdentityRegistry configuration:',
+    `  registry: ${formatAddressOrUnset(current.registry)}`,
+    `  nameWrapper: ${formatAddressOrUnset(current.nameWrapper)}`,
+    `  agentRootHash: ${formatHashOrUnset(current.agentRootHash)}`,
+    `  clubRootHash: ${formatHashOrUnset(current.clubRootHash)}`,
+    `  alphaClubRootHash: ${formatHashOrUnset(current.alphaClubRootHash)}`,
+    `  alphaEnabled: ${Boolean(current.alphaEnabled)}`,
+  ];
+}
+
+function formatPlanLines(plan) {
+  const lines = [];
+  lines.push('Planned IdentityRegistry.configureEns update:');
+  Object.entries(plan.diff).forEach(([key, { previous, next }]) => {
+    let formatter;
+    if (key === 'registry' || key === 'nameWrapper') {
+      formatter = (value) => formatAddressOrUnset(value);
+    } else if (key === 'alphaEnabled') {
+      formatter = (value) => (value ? 'true' : 'false');
+    } else {
+      formatter = (value) => formatHashOrUnset(value);
+    }
+    lines.push(`  ${key}: ${formatDiffEntry(previous, next, formatter)}`);
+  });
+  if (lines.length === 1) {
+    lines.push('  (no changes)');
+  }
+  return lines;
+}
+
+async function collectCurrentConfig(identity) {
+  const [registry, nameWrapper, agentRootHash, clubRootHash, alphaClubRootHash, alphaEnabled] =
+    await Promise.all([
+      identity.ensRegistry(),
+      identity.ensNameWrapper(),
+      identity.agentRootHash(),
+      identity.clubRootHash(),
+      identity.alphaClubRootHash(),
+      identity.alphaEnabled(),
+    ]);
+
+  return {
+    registry: registry || null,
+    nameWrapper: nameWrapper || null,
+    agentRootHash: agentRootHash || null,
+    clubRootHash: clubRootHash || null,
+    alphaClubRootHash: alphaClubRootHash || null,
+    alphaEnabled: Boolean(alphaEnabled),
+  };
+}
+
+module.exports = {
+  ACTIONS,
+  parseBooleanFlag,
+  parseIdentityConsoleArgs,
+  loadEnsConfig,
+  deriveDesiredConfig,
+  buildSetPlan,
+  formatStatusLines,
+  formatPlanLines,
+  collectCurrentConfig,
+};

--- a/test/identityRegistryConsoleLib.test.js
+++ b/test/identityRegistryConsoleLib.test.js
@@ -1,0 +1,154 @@
+const { expect } = require('chai');
+const { hash: namehash } = require('eth-ens-namehash');
+
+const {
+  ACTIONS,
+  parseIdentityConsoleArgs,
+  deriveDesiredConfig,
+  buildSetPlan,
+  formatPlanLines,
+  formatStatusLines,
+} = require('../scripts/lib/identity-registry-console');
+
+function addressOf(digit) {
+  return `0x${digit.repeat(40)}`;
+}
+
+function hashOf(digit) {
+  return `0x${digit.repeat(64)}`;
+}
+
+describe('identity-registry-console library', () => {
+  it('parses CLI arguments with overrides and execution flags', () => {
+    const argv = [
+      'node',
+      'script.js',
+      '--from',
+      addressOf('1'),
+      '--execute=false',
+      '--ens.registry',
+      addressOf('a'),
+      '--ens.alphaEnabled=true',
+      'set',
+    ];
+
+    const parsed = parseIdentityConsoleArgs(argv);
+    expect(parsed.action).to.equal(ACTIONS.SET);
+    expect(parsed.from).to.equal(addressOf('1'));
+    expect(parsed.execute).to.be.false;
+    expect(parsed.overrides.registry).to.equal(addressOf('a'));
+    expect(parsed.overrides.alphaEnabled).to.equal('true');
+  });
+
+  it('derives desired configuration from base config and overrides', () => {
+    const clubHash = namehash('club.agi.eth');
+    const alphaHash = namehash('alpha.club.agi.eth');
+
+    const desired = deriveDesiredConfig(
+      {
+        registry: addressOf('2'),
+        nameWrapper: '',
+        agentRoot: 'Agent.AGI.eth',
+        clubRootHash: clubHash,
+        alphaClubRoot: 'Alpha.Club.AGI.eth',
+        alphaEnabled: true,
+      },
+      {
+        nameWrapper: addressOf('3'),
+        agentRootHash: hashOf('b'),
+        alphaEnabled: 'false',
+      }
+    );
+
+    expect(desired.registry).to.equal(addressOf('2'));
+    expect(desired.nameWrapper).to.equal(addressOf('3'));
+    expect(desired.agentRootHash).to.equal(hashOf('b'));
+    expect(desired.clubRootHash).to.equal(clubHash);
+    expect(desired.alphaClubRootHash).to.equal(alphaHash);
+    expect(desired.alphaEnabled).to.be.false;
+  });
+
+  it('throws when required ENS parameters are missing', () => {
+    expect(() =>
+      deriveDesiredConfig(
+        {
+          registry: null,
+          nameWrapper: '',
+          agentRoot: 'agent.agi.eth',
+          clubRoot: 'club.agi.eth',
+        },
+        {}
+      )
+    ).to.throw('IdentityRegistry.configureEns requires a non-zero registry address');
+  });
+
+  it('builds set plan diffs and arguments for configureEns', () => {
+    const agentHash = namehash('agent.agi.eth');
+    const clubHash = namehash('club.agi.eth');
+    const alphaHash = namehash('alpha.club.agi.eth');
+
+    const plan = buildSetPlan({
+      current: {
+        registry: addressOf('4'),
+        nameWrapper: null,
+        agentRootHash: agentHash,
+        clubRootHash: clubHash,
+        alphaClubRootHash: null,
+        alphaEnabled: false,
+      },
+      baseConfig: {
+        registry: addressOf('4'),
+        nameWrapper: null,
+        agentRoot: 'agent.agi.eth',
+        clubRoot: 'club.agi.eth',
+        alphaClubRoot: 'alpha.club.agi.eth',
+        alphaEnabled: false,
+      },
+      overrides: {
+        alphaEnabled: 'true',
+      },
+    });
+
+    expect(plan.changed).to.be.true;
+    expect(plan.args).to.deep.equal([
+      addressOf('4'),
+      '0x0000000000000000000000000000000000000000',
+      agentHash,
+      clubHash,
+      alphaHash,
+      true,
+    ]);
+    expect(plan.diff).to.have.property('alphaClubRootHash');
+    expect(plan.diff.alphaClubRootHash.next).to.equal(alphaHash);
+    expect(plan.diff.alphaEnabled.next).to.be.true;
+
+    const planLines = formatPlanLines(plan);
+    expect(planLines[0]).to.include('Planned IdentityRegistry.configureEns update');
+    expect(planLines).to.include(`  alphaClubRootHash: (unset) -> ${alphaHash}`);
+    expect(planLines).to.include('  alphaEnabled: false -> true');
+  });
+
+  it('formats current status with unset markers', () => {
+    const agentHash = namehash('agent.agi.eth');
+    const clubHash = namehash('club.agi.eth');
+
+    const lines = formatStatusLines({
+      registry: addressOf('5'),
+      nameWrapper: null,
+      agentRootHash: agentHash,
+      clubRootHash: clubHash,
+      alphaClubRootHash: null,
+      alphaEnabled: false,
+    });
+
+    expect(lines).to.deep.equal([
+      'On-chain IdentityRegistry configuration:',
+      `  registry: ${addressOf('5')}`,
+      '  nameWrapper: (unset)',
+      `  agentRootHash: ${agentHash}`,
+      `  clubRootHash: ${clubHash}`,
+      '  alphaClubRootHash: (unset)',
+      '  alphaEnabled: false',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- harden the Echidna GitHub Actions workflow by adding authenticated release downloads and jq fallback installation
- add unit coverage for the identity registry console helper covering argument parsing, diff planning, and status formatting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1970bf3448333bc483d88cb959320