### PR TITLE
feat: add backup support to params editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+*.bak
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Edit configuration files under `config/` to match the deployment environment:
   `mainnet`).
 - `config/params.json` — Commit/reveal/dispute windows and governance thresholds. Run
   `npm run config:params` for an interactive editor that validates ranges, highlights
-  changes, and writes the updated JSON back to disk. Non-interactive environments can
-  provide explicit overrides via `npm run config:params -- --no-interactive --set feeBps=300 --yes`.
+  changes, and writes the updated JSON back to disk. Add `--backup` to create a timestamped
+  copy of the existing file automatically, or provide an explicit destination via
+  `--backup ./path/to/params.backup.json`. Non-interactive environments can provide
+  explicit overrides via `npm run config:params -- --no-interactive --set feeBps=300 --yes`.
 - Run `npm run config:validate` after editing to confirm addresses, namehashes, and governance parameters satisfy production
   guardrails before broadcasting migrations.
 

--- a/test/paramsEditor.test.js
+++ b/test/paramsEditor.test.js
@@ -1,0 +1,87 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const {
+  parseArgs,
+  resolveBackupPath,
+} = require('../scripts/edit-params');
+
+function createTempDir(prefix) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  return base;
+}
+
+describe('params editor CLI', () => {
+  it('parses inline overrides and backup flags', () => {
+    const inline = parseArgs([
+      'node',
+      'script',
+      '--set=feeBps=300',
+      '--backup',
+      '--no-interactive',
+    ]);
+    expect(inline.set).to.deep.equal({ feeBps: '300' });
+    expect(inline.backup).to.equal(true);
+    expect(inline.interactive).to.be.false;
+
+    const custom = parseArgs([
+      'node',
+      'script',
+      '--backup',
+      './params.backup.json',
+      '--set',
+      'quorumMin=5',
+    ]);
+    expect(custom.backup).to.equal(path.resolve('./params.backup.json'));
+    expect(custom.set).to.deep.equal({ quorumMin: '5' });
+
+    const disabled = parseArgs(['node', 'script', '--backup=false']);
+    expect(disabled.backup).to.be.false;
+  });
+
+  it('resolves automatic backup paths with sanitized timestamps', () => {
+    const now = new Date('2024-01-02T03:04:05.678Z');
+    const resolved = resolveBackupPath('/tmp/params.json', true, { now });
+    expect(resolved).to.equal('/tmp/params.json.2024-01-02T03-04-05-678Z.bak');
+
+    const explicit = resolveBackupPath('/tmp/params.json', 'custom/backup.bak');
+    expect(explicit).to.equal(path.resolve('custom/backup.bak'));
+  });
+
+  it('creates a timestamped backup when invoked with --backup', () => {
+    const tmpDir = createTempDir('params-editor-');
+
+    try {
+      const target = path.join(tmpDir, 'params.json');
+      const original = JSON.parse(JSON.stringify(require('../config/params.json')));
+      fs.writeFileSync(target, `${JSON.stringify(original, null, 2)}\n`, 'utf8');
+
+      const scriptPath = path.join(__dirname, '..', 'scripts', 'edit-params.js');
+      execFileSync('node', [
+        scriptPath,
+        '--file',
+        target,
+        '--set',
+        'feeBps=100',
+        '--yes',
+        '--no-interactive',
+        '--backup',
+      ]);
+
+      const files = fs.readdirSync(tmpDir);
+      const backupName = files.find((name) => name.endsWith('.bak'));
+      expect(backupName).to.exist;
+
+      const backupValues = JSON.parse(fs.readFileSync(path.join(tmpDir, backupName), 'utf8'));
+      expect(backupValues.feeBps).to.equal(original.feeBps);
+
+      const updatedValues = JSON.parse(fs.readFileSync(target, 'utf8'));
+      expect(updatedValues.feeBps).to.equal(100);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add --backup/--no-backup flag handling to the params editor CLI and protect inline --set usage
- persist edits through a helper that can create timestamped backups and prevent accidental overwrites
- document the new workflow, ignore backup artifacts, and add regression tests for the CLI utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a0f0a8188333a8bfa6d93527b36f