### PR TITLE
Add Hardhat JobRegistry owner tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ Edit configuration files under `config/` to match the deployment environment:
 - The prompt also verifies sender ownership before broadcasting and emits a JSON summary of every dry run so non-technical
   operators can forward calldata without parsing console output.
 
+### JobRegistry Hardhat tasks
+
+- `npx hardhat job-registry:status --network <network>` mirrors the owner console status view using the Hardhat runtime, so
+  environments that already rely on Hardhat scripts can fetch configuration snapshots and job summaries without switching to
+  Truffle.
+- `npx hardhat job-registry:extend --network <network> --job <id> --commit-extension 3600` (and the related `finalize`,
+  `timeout`, and `resolve` tasks) reproduce the owner console invariants while defaulting to dry-run mode. The tasks emit
+  human-readable summaries, raw calldata, and optional JSON artifacts (`--plan-out ./plan.json`) that multisig operators can
+  import directly.
+- Pass `--execute --from 0xOwner` to broadcast transactions once the plan looks correct. The helper refuses to send from
+  non-owner accounts and keeps parity with the script library by delegating to the shared `job-registry-owner` validation
+  utilities.
+
 ### IdentityRegistry ENS console
 
 - Run `npm run identity:console -- --network <network> status` for a snapshot of the on-chain ENS wiring, including

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 require('@nomiclabs/hardhat-truffle5');
 require('solidity-coverage');
+require('./tasks/jobRegistry');
 
 const { MNEMONIC, RPC_SEPOLIA, RPC_MAINNET } = process.env;
 

--- a/scripts/job-registry-owner-wizard.js
+++ b/scripts/job-registry-owner-wizard.js
@@ -14,6 +14,7 @@ const {
   formatStatusLines,
   formatTxPlanLines,
 } = require('./lib/job-registry-owner');
+const { serializeForJson } = require('./lib/json-utils');
 
 const ACTION_CHOICES = [
   { key: 'status', description: 'Inspect configuration and optional job status (no transaction)' },
@@ -116,45 +117,6 @@ function describeActions(defaultAction) {
     const marker = choice.key === defaultAction ? '*' : ' ';
     console.log(`  ${marker} ${index + 1}. ${choice.key} — ${choice.description}`);
   });
-}
-
-function serializeForJson(value) {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  const valueType = typeof value;
-  if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
-    return value;
-  }
-
-  if (valueType === 'bigint') {
-    return value.toString();
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((entry) => serializeForJson(entry));
-  }
-
-  if (valueType === 'object') {
-    if (
-      value.constructor &&
-      value.constructor.name === 'BN' &&
-      typeof value.toString === 'function'
-    ) {
-      return value.toString();
-    }
-
-    const serialized = {};
-    Object.entries(value).forEach(([key, entry]) => {
-      serialized[key] = serializeForJson(entry);
-    });
-    return serialized;
-  }
-
-  return value;
-}
-
 async function promptOrFallback({
   interactive,
   rl,

--- a/scripts/lib/json-utils.js
+++ b/scripts/lib/json-utils.js
@@ -1,0 +1,40 @@
+'use strict';
+
+function serializeForJson(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  const valueType = typeof value;
+  if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
+    return value;
+  }
+
+  if (valueType === 'bigint') {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => serializeForJson(entry));
+  }
+
+  if (valueType === 'object') {
+    if (value && typeof value.toString === 'function' && value.toString !== Object.prototype.toString) {
+      const stringified = value.toString();
+      if (stringified !== '[object Object]') {
+        return stringified;
+      }
+    }
+
+    return Object.entries(value).reduce((acc, [key, entry]) => {
+      acc[key] = serializeForJson(entry);
+      return acc;
+    }, {});
+  }
+
+  return String(value);
+}
+
+module.exports = {
+  serializeForJson,
+};

--- a/tasks/jobRegistry.js
+++ b/tasks/jobRegistry.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { task, types } = require('hardhat/config');
+
+const {
+  collectOwnerStatus,
+  buildOwnerTxPlan,
+  formatStatusLines,
+  formatTxPlanLines,
+} = require('../scripts/lib/job-registry-owner');
+const { serializeForJson } = require('../scripts/lib/json-utils');
+
+async function resolveRegistry(hre, registryAddress) {
+  const JobRegistry = hre.artifacts.require('JobRegistry');
+  if (registryAddress) {
+    return JobRegistry.at(registryAddress);
+  }
+  return JobRegistry.deployed();
+}
+
+async function resolveSender(hre, explicit) {
+  if (explicit) {
+    return explicit;
+  }
+
+  const accounts = await hre.web3.eth.getAccounts();
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No unlocked accounts are available. Specify --from explicitly.');
+  }
+
+  return accounts[0];
+}
+
+function ensureOwner(sender, owner) {
+  if (!owner) {
+    throw new Error('JobRegistry owner is not configured on-chain.');
+  }
+
+  if (sender.toLowerCase() !== owner.toLowerCase()) {
+    throw new Error(
+      `Sender ${sender} is not the JobRegistry owner (${owner}). ` +
+        'Provide --from with the owner account or forward the generated plan through the owner multisig.',
+    );
+  }
+}
+
+function printLines(lines) {
+  lines.forEach((line) => {
+    console.log(line);
+  });
+}
+
+function buildCallSummary({ plan, callData, registryAddress, sender }) {
+  return {
+    action: plan.action,
+    method: plan.method,
+    args: serializeForJson(plan.args),
+    metadata: serializeForJson(plan.metadata),
+    call: {
+      to: registryAddress,
+      data: callData,
+      value: '0',
+      from: sender || null,
+    },
+  };
+}
+
+function maybeWriteSummary(summary, outputPath) {
+  if (!outputPath) {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+async function handleOwnerAction(hre, args, action) {
+  if (!args.job) {
+    throw new Error('The --job parameter is required for JobRegistry owner actions.');
+  }
+
+  const registry = await resolveRegistry(hre, args.registry);
+  const owner = await registry.owner();
+  const sender = await resolveSender(hre, args.from);
+
+  const planOptions = {
+    action,
+    jobId: args.job,
+  };
+
+  if (action === 'extend') {
+    planOptions.commitExtension = args.commitExtension;
+    planOptions.revealExtension = args.revealExtension;
+    planOptions.disputeExtension = args.disputeExtension;
+  } else if (action === 'finalize') {
+    planOptions.success = args.success;
+  } else if (action === 'timeout') {
+    planOptions.slashAmount = args.slashAmount;
+  } else if (action === 'resolve') {
+    planOptions.slashWorker = args.slashWorker;
+    planOptions.slashAmount = args.slashAmount;
+    planOptions.reputationDelta = args.reputationDelta;
+  }
+
+  const plan = await buildOwnerTxPlan({ registry, web3: hre.web3, options: planOptions });
+  const callData = registry.contract.methods[plan.method](...plan.args).encodeABI();
+  const formatted = formatTxPlanLines(plan, callData, { to: registry.address });
+  printLines(formatted);
+
+  const summary = buildCallSummary({ plan, callData, registryAddress: registry.address, sender });
+
+  if (args.planOut) {
+    const writtenPath = maybeWriteSummary(summary, args.planOut);
+    console.log(`Plan summary written to ${writtenPath}`);
+  }
+
+  if (!args.execute) {
+    console.log('Dry run: transaction not broadcast. Use --execute to submit the transaction.');
+    console.log(JSON.stringify(summary.call, null, 2));
+    return;
+  }
+
+  ensureOwner(sender, owner);
+  const receipt = await registry[plan.method](...plan.args, { from: sender });
+  console.log(`Transaction broadcast. Hash: ${receipt.tx}`);
+}
+
+function registerOwnerTask({ name, description, action, params = [] }) {
+  const ownerTask = task(name, description)
+    .addOptionalParam('registry', 'JobRegistry contract address')
+    .addParam('job', 'Target job identifier')
+    .addOptionalParam('from', 'Sender address', undefined, types.string)
+    .addFlag('execute', 'Broadcast the transaction instead of performing a dry run')
+    .addOptionalParam('planOut', 'Write a transaction summary JSON to the specified path', undefined, types.string);
+
+  params.forEach((param) => {
+    ownerTask.addOptionalParam(param.name, param.description, param.defaultValue, param.type);
+  });
+
+  ownerTask.setAction(async (args, hre) => handleOwnerAction(hre, args, action));
+}
+
+registerOwnerTask({
+  name: 'job-registry:extend',
+  description: "Extend a job's commit/reveal/dispute deadlines",
+  action: 'extend',
+  params: [
+    { name: 'commitExtension', description: 'Additional commit window seconds', defaultValue: '0', type: types.string },
+    { name: 'revealExtension', description: 'Additional reveal window seconds', defaultValue: '0', type: types.string },
+    { name: 'disputeExtension', description: 'Additional dispute window seconds', defaultValue: '0', type: types.string },
+  ],
+});
+
+registerOwnerTask({
+  name: 'job-registry:finalize',
+  description: 'Finalize a revealed job and settle stake',
+  action: 'finalize',
+  params: [
+    { name: 'success', description: 'Whether the job succeeded', defaultValue: true, type: types.boolean },
+  ],
+});
+
+registerOwnerTask({
+  name: 'job-registry:timeout',
+  description: 'Timeout a stalled job after the dispute window elapses',
+  action: 'timeout',
+  params: [
+    { name: 'slashAmount', description: 'Stake amount to slash on timeout', defaultValue: '0', type: types.string },
+  ],
+});
+
+registerOwnerTask({
+  name: 'job-registry:resolve',
+  description: 'Resolve an active dispute with optional slashing and reputation update',
+  action: 'resolve',
+  params: [
+    { name: 'slashWorker', description: 'Slash the worker when resolving the dispute', defaultValue: false, type: types.boolean },
+    { name: 'slashAmount', description: 'Amount of stake to slash from the worker', defaultValue: '0', type: types.string },
+    { name: 'reputationDelta', description: 'Signed reputation delta applied to the worker', defaultValue: '0', type: types.string },
+  ],
+});
+
+task('job-registry:status', 'Inspect JobRegistry configuration and optional job state')
+  .addOptionalParam('registry', 'JobRegistry contract address')
+  .addOptionalParam('job', 'Optional job identifier to inspect', undefined, types.string)
+  .addFlag('json', 'Emit JSON instead of the human-readable summary')
+  .setAction(async (args, hre) => {
+    const registry = await resolveRegistry(hre, args.registry);
+    const owner = await registry.owner();
+    const status = await collectOwnerStatus({
+      registry,
+      web3: hre.web3,
+      owner,
+      jobId: args.job || null,
+    });
+
+    if (args.json) {
+      console.log(JSON.stringify(serializeForJson(status), null, 2));
+      return;
+    }
+
+    console.log('AGIJobsv1 — Hardhat JobRegistry status');
+    console.log(`Contract: ${registry.address}`);
+    console.log('');
+    printLines(formatStatusLines(status));
+  });

--- a/test/jsonUtils.test.js
+++ b/test/jsonUtils.test.js
@@ -1,0 +1,33 @@
+const { expect } = require('chai');
+
+const { serializeForJson } = require('../scripts/lib/json-utils');
+
+describe('json-utils serializeForJson', () => {
+  it('returns primitives unchanged', () => {
+    expect(serializeForJson('value')).to.equal('value');
+    expect(serializeForJson(42)).to.equal(42);
+    expect(serializeForJson(false)).to.equal(false);
+  });
+
+  it('serializes bigint-like values to strings', () => {
+    expect(serializeForJson(12n)).to.equal('12');
+
+    const { BN } = web3.utils;
+    expect(serializeForJson(new BN('9876543210'))).to.equal('9876543210');
+  });
+
+  it('serializes nested structures', () => {
+    const { BN } = web3.utils;
+    const input = {
+      array: [new BN('1'), 2n, true],
+      object: {
+        nested: new BN('3'),
+      },
+    };
+
+    expect(serializeForJson(input)).to.deep.equal({
+      array: ['1', '2', true],
+      object: { nested: '3' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Hardhat tasks that expose JobRegistry owner status and lifecycle actions through the Hardhat runtime
- extract a reusable JSON serialization helper and reuse it in the owner wizard
- document the new workflow and cover the serializer with dedicated unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1b69b833c83339ccfa8d58cf6a1cb