### PR TITLE
Add Hardhat tasks for JobRegistry configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Guided JobRegistry owner wizard with interactive and non-interactive modes, plan exports, and broadcast safeguards.
+- Hardhat `job-registry:set-config` and `job-registry:update-config` tasks that mirror the configuration console with JSON
+  overrides, plan exports, and owner enforcement.
 
 ## [1.1.0] - 2025-02-21
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Edit configuration files under `config/` to match the deployment environment:
 - `npx hardhat job-registry:status --network <network>` mirrors the owner console status view using the Hardhat runtime, so
   environments that already rely on Hardhat scripts can fetch configuration snapshots and job summaries without switching to
   Truffle.
+- `npx hardhat job-registry:set-config --network <network> --modules '{"identity":"0x…"}' --plan-out ./plan.json` aligns
+  modules, timings, and thresholds with `config/params.json` defaults and optional JSON overrides. The task prints a
+  multi-transaction plan with encoded calldata, writes an optional Safe-ready summary, and refuses to broadcast unless `--execute`
+  and an owner sender are supplied.
+- `npx hardhat job-registry:update-config --network <network> --thresholds '{"feeBps":275}' --execute --from 0xOwner` updates a
+  single module, timing, or threshold via the granular update functions. It reuses the same validation guardrails as the
+  configuration console, emits plan summaries, and enforces owner checks before broadcasting.
 - `npx hardhat job-registry:extend --network <network> --job <id> --commit-extension 3600` (and the related `finalize`,
   `timeout`, and `resolve` tasks) reproduce the owner console invariants while defaulting to dry-run mode. The tasks emit
   human-readable summaries, raw calldata, and optional JSON artifacts (`--plan-out ./plan.json`) that multisig operators can

--- a/docs/parameter-management.md
+++ b/docs/parameter-management.md
@@ -107,3 +107,6 @@ resulting JSON without persisting changes when running audits or experiments.
 - `npm run configure:registry` and `npm run config:wizard` reuse the same parsing
   helpers when staging on-chain updates, so any improvements made here carry
   through to owner workflows automatically.
+- Hardhat operators can call `npx hardhat job-registry:set-config --network <network> --timings '{"commitWindow":3600}'`
+  or `npx hardhat job-registry:update-config --thresholds '{"feeBps":275}'` to apply the validated parameters on-chain
+  with plan exports and owner enforcement without leaving the Hardhat environment.

--- a/scripts/lib/job-registry-config-defaults.js
+++ b/scripts/lib/job-registry-config-defaults.js
@@ -1,22 +1,34 @@
 'use strict';
 
-const IdentityRegistry = artifacts.require('IdentityRegistry');
-const StakeManager = artifacts.require('StakeManager');
-const ValidationModule = artifacts.require('ValidationModule');
-const DisputeModule = artifacts.require('DisputeModule');
-const ReputationEngine = artifacts.require('ReputationEngine');
-const FeePool = artifacts.require('FeePool');
-
 const { MODULE_KEYS } = require('./job-registry-configurator');
 
-const MODULE_ARTIFACTS = {
-  identity: IdentityRegistry,
-  staking: StakeManager,
-  validation: ValidationModule,
-  dispute: DisputeModule,
-  reputation: ReputationEngine,
-  feePool: FeePool,
+const MODULE_ARTIFACT_NAMES = {
+  identity: 'IdentityRegistry',
+  staking: 'StakeManager',
+  validation: 'ValidationModule',
+  dispute: 'DisputeModule',
+  reputation: 'ReputationEngine',
+  feePool: 'FeePool',
 };
+
+function resolveArtifacts() {
+  if (typeof artifacts === 'undefined' || !artifacts || typeof artifacts.require !== 'function') {
+    throw new Error(
+      'Truffle artifacts are not available. Ensure @nomiclabs/hardhat-truffle5 is loaded before resolving module defaults.'
+    );
+  }
+
+  return MODULE_ARTIFACT_NAMES;
+}
+
+function getArtifactByKey(key) {
+  const mapping = resolveArtifacts();
+  const name = mapping[key];
+  if (!name) {
+    return null;
+  }
+  return artifacts.require(name);
+}
 
 async function resolveModuleDefaults(overrides) {
   const defaults = {};
@@ -26,7 +38,7 @@ async function resolveModuleDefaults(overrides) {
       continue;
     }
 
-    const artifact = MODULE_ARTIFACTS[key];
+    const artifact = getArtifactByKey(key);
     if (!artifact) {
       continue;
     }
@@ -45,6 +57,6 @@ async function resolveModuleDefaults(overrides) {
 }
 
 module.exports = {
-  MODULE_ARTIFACTS,
+  MODULE_ARTIFACT_NAMES,
   resolveModuleDefaults,
 };

--- a/tasks/jobRegistry.js
+++ b/tasks/jobRegistry.js
@@ -10,6 +10,25 @@ const {
   formatStatusLines,
   formatTxPlanLines,
 } = require('../scripts/lib/job-registry-owner');
+const {
+  buildSetPlans,
+  buildUpdatePlan,
+  formatPlanDiff,
+} = require('../scripts/lib/job-registry-config-console');
+const {
+  loadParamsConfig,
+  formatAddress,
+  formatDiffEntry,
+  normalizeModuleStruct,
+  normalizeNumericStruct,
+} = require('../scripts/lib/job-registry-config-utils');
+const { resolveModuleDefaults } = require('../scripts/lib/job-registry-config-defaults');
+const {
+  buildSetPlanSummary,
+  buildUpdatePlanSummary,
+  writePlanSummary,
+} = require('../scripts/lib/job-registry-plan-writer');
+const { TIMING_KEYS, THRESHOLD_KEYS } = require('../scripts/lib/job-registry-configurator');
 const { serializeForJson } = require('../scripts/lib/json-utils');
 
 async function resolveRegistry(hre, registryAddress) {
@@ -76,6 +95,98 @@ function maybeWriteSummary(summary, outputPath) {
   fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
   fs.writeFileSync(resolvedPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
   return resolvedPath;
+}
+
+function ensurePlainObject(label, value) {
+  if (value === undefined || value === null) {
+    return {};
+  }
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} overrides must be provided as a JSON object`);
+  }
+
+  return value;
+}
+
+function parseOverrideArgs(args) {
+  return {
+    modules: ensurePlainObject('modules', args.modules),
+    timings: ensurePlainObject('timings', args.timings),
+    thresholds: ensurePlainObject('thresholds', args.thresholds),
+  };
+}
+
+async function collectConfigurationSnapshot(registry) {
+  const [modules, timings, thresholds, status] = await Promise.all([
+    registry.modules(),
+    registry.timings(),
+    registry.thresholds(),
+    registry.configurationStatus(),
+  ]);
+
+  return {
+    modules: normalizeModuleStruct(modules),
+    timings: normalizeNumericStruct(timings, TIMING_KEYS),
+    thresholds: normalizeNumericStruct(thresholds, THRESHOLD_KEYS),
+    status: {
+      modules: Boolean(status[0]),
+      timings: Boolean(status[1]),
+      thresholds: Boolean(status[2]),
+    },
+  };
+}
+
+function describeConfigurationStatus(status) {
+  const icon = (value) => (value ? '✓' : '✗');
+  return `modules=${icon(status.modules)} timings=${icon(status.timings)} thresholds=${icon(status.thresholds)}`;
+}
+
+function printPlanDiffSection(label, plan, formatter) {
+  if (!plan || !plan.changed) {
+    console.log(`- ${label}: no changes required.`);
+    return;
+  }
+
+  console.log(`- ${label}:`);
+  Object.entries(plan.diff).forEach(([key, diff]) => {
+    console.log(`    ${key}: ${formatDiffEntry(diff.previous, diff.next, formatter)}`);
+  });
+}
+
+function hasSetPlanChanges(plans) {
+  return Boolean(
+    (plans.modulesPlan && plans.modulesPlan.changed) ||
+      (plans.timingsPlan && plans.timingsPlan.changed) ||
+      (plans.thresholdsPlan && plans.thresholdsPlan.changed)
+  );
+}
+
+function printTransactionSteps(steps) {
+  if (!Array.isArray(steps) || steps.length === 0) {
+    console.log('No transactions are required — configuration already matches the desired state.');
+    return;
+  }
+
+  console.log('Planned transactions:');
+  steps.forEach((step, index) => {
+    console.log(`  [${index + 1}] ${step.description}`);
+    console.log(`      args: ${JSON.stringify(step.arguments)}`);
+    console.log(`      to: ${step.call.to}`);
+    console.log(`      data: ${step.call.data}`);
+  });
+}
+
+function selectDiffFormatter(section, web3Instance) {
+  if (section === 'modules') {
+    return (value) => formatAddress(value, web3Instance);
+  }
+
+  if (section === 'timings') {
+    return (value) => `${value} seconds`;
+  }
+
+  return (value) => `${value}`;
 }
 
 async function handleOwnerAction(hre, args, action) {
@@ -207,4 +318,177 @@ task('job-registry:status', 'Inspect JobRegistry configuration and optional job 
     console.log(`Contract: ${registry.address}`);
     console.log('');
     printLines(formatStatusLines(status));
+  });
+
+task('job-registry:set-config', 'Align JobRegistry configuration using repository defaults and optional overrides')
+  .addOptionalParam('registry', 'JobRegistry contract address')
+  .addOptionalParam('from', 'Sender address', undefined, types.string)
+  .addOptionalParam('modules', 'JSON object of module overrides keyed by module name', undefined, types.json)
+  .addOptionalParam('timings', 'JSON object of timing overrides keyed by lifecycle window', undefined, types.json)
+  .addOptionalParam('thresholds', 'JSON object of threshold overrides keyed by governance field', undefined, types.json)
+  .addOptionalParam('params', 'Path to params.json providing timing/threshold defaults', undefined, types.string)
+  .addOptionalParam('variant', 'Optional configuration variant label for plan metadata', undefined, types.string)
+  .addOptionalParam('planOut', 'Write the generated plan summary JSON to the specified path', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transactions instead of performing a dry run')
+  .setAction(async (args, hre) => {
+    const registry = await resolveRegistry(hre, args.registry);
+    const owner = await registry.owner();
+    const sender = await resolveSender(hre, args.from);
+
+    const overrides = parseOverrideArgs(args);
+    const snapshot = await collectConfigurationSnapshot(registry);
+    const paramsConfig = loadParamsConfig(args.params);
+    const moduleDefaults = await resolveModuleDefaults(overrides.modules);
+
+    const plans = buildSetPlans({
+      currentModules: snapshot.modules,
+      currentTimings: snapshot.timings,
+      currentThresholds: snapshot.thresholds,
+      overrides,
+      defaults: {
+        modules: moduleDefaults,
+        timings: paramsConfig.values,
+        thresholds: paramsConfig.values,
+      },
+    });
+
+    console.log('AGIJobsv1 — Hardhat JobRegistry set-config');
+    console.log(`Contract: ${registry.address}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log(`Sender: ${sender}`);
+    console.log(`Configuration: ${describeConfigurationStatus(snapshot.status)}`);
+    console.log('');
+
+    printPlanDiffSection('Modules', plans.modulesPlan, (value) => formatAddress(value, hre.web3));
+    printPlanDiffSection('Timings', plans.timingsPlan, (value) => `${value} seconds`);
+    printPlanDiffSection('Thresholds', plans.thresholdsPlan, (value) => `${value}`);
+    console.log('');
+
+    const summary = buildSetPlanSummary({
+      jobRegistry: registry,
+      jobRegistryAddress: registry.address,
+      sender,
+      plans,
+      configuration: snapshot.status,
+      variant: args.variant || null,
+      dryRun: !args.execute,
+    });
+
+    if (args.planOut) {
+      const writtenPath = writePlanSummary(summary, args.planOut);
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!hasSetPlanChanges(plans)) {
+      console.log('No configuration changes required.');
+      return;
+    }
+
+    if (owner && owner.toLowerCase() !== sender.toLowerCase()) {
+      console.warn(
+        `Warning: sender ${sender} is not the JobRegistry owner (${owner}). Transactions may revert unless forwarded through the owner account.`
+      );
+    }
+
+    printTransactionSteps(summary.steps);
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the planned transactions.');
+      return;
+    }
+
+    ensureOwner(sender, owner);
+
+    if (plans.modulesPlan.changed) {
+      const receipt = await registry.setModules(plans.modulesPlan.desired, { from: sender });
+      console.log(`✓ setModules tx: ${receipt.tx}`);
+    }
+
+    if (plans.timingsPlan.changed) {
+      const { commitWindow, revealWindow, disputeWindow } = plans.timingsPlan.desired;
+      const receipt = await registry.setTimings(commitWindow, revealWindow, disputeWindow, { from: sender });
+      console.log(`✓ setTimings tx: ${receipt.tx}`);
+    }
+
+    if (plans.thresholdsPlan.changed) {
+      const { approvalThresholdBps, quorumMin, quorumMax, feeBps, slashBpsMax } = plans.thresholdsPlan.desired;
+      const receipt = await registry.setThresholds(
+        approvalThresholdBps,
+        quorumMin,
+        quorumMax,
+        feeBps,
+        slashBpsMax,
+        { from: sender }
+      );
+      console.log(`✓ setThresholds tx: ${receipt.tx}`);
+    }
+  });
+
+task('job-registry:update-config', 'Update a single JobRegistry module, timing, or threshold value')
+  .addOptionalParam('registry', 'JobRegistry contract address')
+  .addOptionalParam('from', 'Sender address', undefined, types.string)
+  .addOptionalParam('modules', 'JSON object containing the module override to apply', undefined, types.json)
+  .addOptionalParam('timings', 'JSON object containing the timing override to apply', undefined, types.json)
+  .addOptionalParam('thresholds', 'JSON object containing the threshold override to apply', undefined, types.json)
+  .addOptionalParam('variant', 'Optional configuration variant label for plan metadata', undefined, types.string)
+  .addOptionalParam('planOut', 'Write the generated plan summary JSON to the specified path', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run')
+  .setAction(async (args, hre) => {
+    const registry = await resolveRegistry(hre, args.registry);
+    const owner = await registry.owner();
+    const sender = await resolveSender(hre, args.from);
+
+    const overrides = parseOverrideArgs(args);
+    const snapshot = await collectConfigurationSnapshot(registry);
+    const plan = buildUpdatePlan({
+      overrides,
+      currentModules: snapshot.modules,
+      currentTimings: snapshot.timings,
+      currentThresholds: snapshot.thresholds,
+    });
+
+    console.log('AGIJobsv1 — Hardhat JobRegistry update-config');
+    console.log(`Contract: ${registry.address}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log(`Sender: ${sender}`);
+    console.log(`Configuration: ${describeConfigurationStatus(snapshot.status)}`);
+    console.log('');
+
+    const formatter = selectDiffFormatter(plan.summary.section, hre.web3);
+    console.log(
+      `- ${plan.summary.section}.${plan.summary.key}: ${formatPlanDiff(plan.summary, formatter)}`
+    );
+    console.log('');
+
+    const summary = buildUpdatePlanSummary({
+      jobRegistry: registry,
+      jobRegistryAddress: registry.address,
+      sender,
+      plan,
+      configuration: snapshot.status,
+      variant: args.variant || null,
+      dryRun: !args.execute,
+    });
+
+    if (args.planOut) {
+      const writtenPath = writePlanSummary(summary, args.planOut);
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (owner && owner.toLowerCase() !== sender.toLowerCase()) {
+      console.warn(
+        `Warning: sender ${sender} is not the JobRegistry owner (${owner}). Transactions may revert unless forwarded through the owner account.`
+      );
+    }
+
+    printTransactionSteps(summary.steps);
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to submit the transaction.');
+      return;
+    }
+
+    ensureOwner(sender, owner);
+    const receipt = await registry[plan.method](...plan.args, { from: sender });
+    console.log(`✓ ${plan.method} tx: ${receipt.tx}`);
   });


### PR DESCRIPTION
## Summary
- add Hardhat tasks for aligning JobRegistry modules/timings/thresholds and for granular updates with dry-run planning, owner checks, and JSON overrides
- refactor the module default resolver to lazily load Truffle artifacts so tasks can run during Hardhat startup
- document the new workflow in the README and parameter-management guide and record the addition in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c9f2961c8333986a8deb82fdf8c3