### PR TITLE
Add Hardhat IdentityRegistry management tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Guided JobRegistry owner wizard with interactive and non-interactive modes, plan exports, and broadcast safeguards.
 - Hardhat `job-registry:set-config` and `job-registry:update-config` tasks that mirror the configuration console with JSON
   overrides, plan exports, and owner enforcement.
+- Hardhat `identity-registry:status` and `identity-registry:set-config` tasks so ENS owners can audit and update wiring without
+  leaving the Hardhat workflow.
 
 ## [1.1.0] - 2025-02-21
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Edit configuration files under `config/` to match the deployment environment:
   non-owner accounts and keeps parity with the script library by delegating to the shared `job-registry-owner` validation
   utilities.
 
+### IdentityRegistry Hardhat tasks
+
+- `npx hardhat identity-registry:status --network <network>` prints the on-chain ENS configuration, automatically compares it
+  against the repository config profile (or an explicit `--config` path), and highlights any drift together with optional
+  override previews such as `--overrides '{"alphaEnabled":true}'`.
+- `npx hardhat identity-registry:set-config --network <network> --execute --from 0xOwner` aligns the ENS wiring with
+  repository defaults and overrides, writes optional Safe-ready JSON plans via `--plan-out`, enforces owner checks before
+  broadcasting, and emits a dry-run transaction summary when `--execute` is omitted.
+
 ### IdentityRegistry ENS console
 
 - Run `npm run identity:console -- --network <network> status` for a snapshot of the on-chain ENS wiring, including

--- a/tasks/identityRegistry.js
+++ b/tasks/identityRegistry.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { task, types } = require('hardhat/config');
+
+const {
+  loadEnsConfig,
+  buildSetPlan,
+  formatStatusLines,
+  formatPlanLines,
+  collectCurrentConfig,
+} = require('../scripts/lib/identity-registry-console');
+const { resolveVariant } = require('../scripts/config-loader');
+const { toChecksum } = require('../scripts/lib/job-registry-config-utils');
+const { serializeForJson } = require('../scripts/lib/json-utils');
+
+async function resolveIdentity(hre, explicitAddress) {
+  const IdentityRegistry = hre.artifacts.require('IdentityRegistry');
+  if (explicitAddress) {
+    return IdentityRegistry.at(explicitAddress);
+  }
+  return IdentityRegistry.deployed();
+}
+
+async function resolveSender(hre, explicit) {
+  if (explicit) {
+    if (!hre.web3.utils.isAddress(explicit)) {
+      throw new Error(`Invalid --from address: ${explicit}`);
+    }
+    return toChecksum(explicit);
+  }
+
+  const accounts = await hre.web3.eth.getAccounts();
+  if (!accounts || accounts.length === 0) {
+    throw new Error('No unlocked accounts are available. Specify --from explicitly.');
+  }
+
+  return toChecksum(accounts[0]);
+}
+
+function ensureOwner(sender, owner) {
+  if (!owner) {
+    throw new Error('IdentityRegistry owner is not configured on-chain.');
+  }
+
+  if (sender.toLowerCase() !== owner.toLowerCase()) {
+    throw new Error(
+      `Sender ${sender} is not the IdentityRegistry owner (${owner}). ` +
+        'Provide --from with the owner account or forward the generated plan through the owner multisig.',
+    );
+  }
+}
+
+function maybeWriteSummary(summary, outputPath) {
+  if (!outputPath) {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+function buildPlanSummary({
+  identityAddress,
+  owner,
+  sender,
+  plan,
+  callData,
+  configProfile,
+}) {
+  return {
+    identityRegistry: identityAddress,
+    owner,
+    sender,
+    config: {
+      path: configProfile.path,
+      variant: configProfile.variant,
+    },
+    desired: serializeForJson(plan.desired),
+    diff: serializeForJson(plan.diff),
+    arguments: serializeForJson(plan.args),
+    call: {
+      to: identityAddress,
+      data: callData,
+      value: '0',
+      from: sender || null,
+    },
+  };
+}
+
+function resolveVariantWithWarning(candidate) {
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    return resolveVariant(candidate);
+  } catch (error) {
+    console.warn(`Warning: unable to resolve variant for "${candidate}": ${error.message}`);
+    return null;
+  }
+}
+
+task('identity-registry:status', 'Inspect IdentityRegistry ENS configuration and optional drift against config files')
+  .addOptionalParam('identity', 'IdentityRegistry contract address', undefined, types.string)
+  .addOptionalParam('config', 'Explicit ENS config file path', undefined, types.string)
+  .addOptionalParam('variant', 'Config variant hint (mainnet, sepolia, dev)', undefined, types.string)
+  .addOptionalParam(
+    'overrides',
+    'JSON object of overrides (for example {"alphaEnabled":true,"agentRoot":"agents.agi.eth"})',
+    undefined,
+    types.json,
+  )
+  .setAction(async (args, hre) => {
+    const identity = await resolveIdentity(hre, args.identity);
+    const identityAddress = toChecksum(identity.address);
+    const owner = toChecksum(await identity.owner());
+    const current = await collectCurrentConfig(identity);
+
+    const networkName = hre.network && hre.network.name ? hre.network.name : '(unspecified)';
+    const variantHint = args.variant || networkName || undefined;
+    const resolvedVariant = resolveVariantWithWarning(variantHint);
+    const variantForConfig = args.config ? null : resolvedVariant || args.variant || networkName || undefined;
+
+    console.log('AGIJobsv1 — IdentityRegistry Hardhat console');
+    console.log('Action: status');
+    console.log(`Network: ${networkName}${resolvedVariant ? ` (variant: ${resolvedVariant})` : ''}`);
+    console.log(`IdentityRegistry: ${identityAddress}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log('');
+
+    formatStatusLines(current).forEach((line) => console.log(line));
+    console.log('');
+
+    const overrides = args.overrides || {};
+
+    try {
+      const configProfile = loadEnsConfig({
+        explicitPath: args.config,
+        variant: args.config ? undefined : variantForConfig,
+      });
+      console.log(`Config file: ${configProfile.path}`);
+      const plan = buildSetPlan({ current, baseConfig: configProfile.values, overrides });
+      if (plan.changed) {
+        console.log('');
+        formatPlanLines(plan).forEach((line) => console.log(line));
+      } else {
+        console.log('\nOn-chain configuration already matches the desired profile.');
+      }
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      console.warn(`Warning: unable to evaluate configuration drift: ${message}`);
+    }
+  });
+
+task('identity-registry:set-config', 'Align IdentityRegistry ENS configuration with repository defaults and optional overrides')
+  .addOptionalParam('identity', 'IdentityRegistry contract address', undefined, types.string)
+  .addOptionalParam('from', 'Sender address (defaults to first unlocked account)', undefined, types.string)
+  .addOptionalParam('config', 'Explicit ENS config file path', undefined, types.string)
+  .addOptionalParam('variant', 'Config variant hint (mainnet, sepolia, dev)', undefined, types.string)
+  .addOptionalParam(
+    'overrides',
+    'JSON object of overrides (for example {"alphaEnabled":true,"agentRoot":"agents.agi.eth"})',
+    undefined,
+    types.json,
+  )
+  .addOptionalParam('planOut', 'Path to write a Safe-ready transaction summary JSON', undefined, types.string)
+  .addFlag('execute', 'Broadcast the configureEns transaction')
+  .setAction(async (args, hre) => {
+    const identity = await resolveIdentity(hre, args.identity);
+    const identityAddress = toChecksum(identity.address);
+    const owner = toChecksum(await identity.owner());
+    const sender = await resolveSender(hre, args.from);
+    const current = await collectCurrentConfig(identity);
+
+    const networkName = hre.network && hre.network.name ? hre.network.name : '(unspecified)';
+    const variantHint = args.variant || networkName || undefined;
+    const resolvedVariant = resolveVariantWithWarning(variantHint);
+    const variantForConfig = args.config ? null : resolvedVariant || args.variant || networkName || undefined;
+
+    console.log('AGIJobsv1 — IdentityRegistry Hardhat console');
+    console.log('Action: set-config');
+    console.log(`Network: ${networkName}${resolvedVariant ? ` (variant: ${resolvedVariant})` : ''}`);
+    console.log(`IdentityRegistry: ${identityAddress}`);
+    console.log(`Owner: ${owner || '(unknown)'}`);
+    console.log(`Sender: ${sender}`);
+    console.log('');
+
+    formatStatusLines(current).forEach((line) => console.log(line));
+    console.log('');
+
+    const overrides = args.overrides || {};
+
+    let configProfile;
+    try {
+      configProfile = loadEnsConfig({
+        explicitPath: args.config,
+        variant: args.config ? undefined : variantForConfig,
+      });
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      throw new Error(`Unable to load ENS configuration: ${message}`);
+    }
+
+    console.log(`Config file: ${configProfile.path}`);
+
+    const plan = buildSetPlan({ current, baseConfig: configProfile.values, overrides });
+
+    console.log('');
+    formatPlanLines(plan).forEach((line) => console.log(line));
+
+    if (!plan.changed) {
+      console.log('\nOn-chain configuration already matches the desired profile.');
+      return;
+    }
+
+    const callData = identity.contract.methods.configureEns(...plan.args).encodeABI();
+    const summary = buildPlanSummary({
+      identityAddress,
+      owner,
+      sender,
+      plan,
+      callData,
+      configProfile,
+    });
+
+    if (args.planOut) {
+      const written = maybeWriteSummary(summary, args.planOut);
+      console.log(`\nPlan summary written to ${written}`);
+    }
+
+    if (!args.execute) {
+      console.log('\nDry run: transaction not broadcast.');
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    ensureOwner(sender, owner);
+
+    const receipt = await identity.configureEns(...plan.args, { from: sender });
+    console.log(`\nTransaction broadcast. Hash: ${receipt.tx}`);
+  });


### PR DESCRIPTION
## Summary
- add Hardhat tasks to inspect and align IdentityRegistry ENS configuration with repository profiles, owner checks, and plan exports
- document the new Hardhat workflow for IdentityRegistry operators and note it in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d632f2e4833394f38f5d248a340d