### PR TITLE
Fix coverage env and ENS migration defaults

### DIFF
--- a/migrations/4_configure_ens_and_params.js
+++ b/migrations/4_configure_ens_and_params.js
@@ -5,12 +5,17 @@ module.exports = async function (_deployer, network, _accounts) {
   const ensCfg = readConfig('ens', network);
   const identity = await IdentityRegistry.deployed();
   if (ensCfg.agentRootHash && ensCfg.clubRootHash) {
+    const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+    const ZERO_NAMEHASH = '0x0000000000000000000000000000000000000000000000000000000000000000';
+    const wrapperAddress = ensCfg.nameWrapper || ZERO_ADDRESS;
+    const alphaHash = ensCfg.alphaClubRootHash || ZERO_NAMEHASH;
+
     await identity.configureEns(
       ensCfg.registry,
-      ensCfg.nameWrapper,
+      wrapperAddress,
       ensCfg.agentRootHash,
       ensCfg.clubRootHash,
-      ensCfg.alphaClubRootHash || '0x'.padEnd(66, '0'),
+      alphaHash,
       Boolean(ensCfg.alphaEnabled)
     );
   }

--- a/tools/truffle-hardhat-coverage/index.js
+++ b/tools/truffle-hardhat-coverage/index.js
@@ -8,7 +8,14 @@ module.exports = function runHardhatCoverage(config) {
     const child = spawn(process.execPath, args, {
       cwd: config.working_directory,
       stdio: 'inherit',
-      env: { ...process.env },
+      env: {
+        ...process.env,
+        // Ensure downstream tests know they are running under coverage so that
+        // instrumentation-induced gas inflation does not break guardrail checks.
+        SOLIDITY_COVERAGE: process.env.SOLIDITY_COVERAGE || 'true',
+        COVERAGE: process.env.COVERAGE || 'true',
+        SKIP_GAS_ASSERTS: process.env.SKIP_GAS_ASSERTS || 'true',
+      },
     });
 
     child.on('error', reject);


### PR DESCRIPTION
## Summary
- ensure the hardhat coverage bridge injects SOLIDITY_COVERAGE and related flags so gas guardrails are skipped during instrumentation runs
- treat missing ENS name-wrapper or alpha hashes as zero values when configuring IdentityRegistry so development migrations succeed

## Testing
- npm run build
- npm run config:validate
- npm run config:params -- --no-interactive --dry-run
- npm run lint:sol
- npm run test
- npm run coverage
- npm run gas | tee gas-report.txt
- npm run export:artifacts
- npm run wire:verify
- npm run registrar:verify

------
https://chatgpt.com/codex/tasks/task_e_68d2eb6787dc8333815c127a147bce7f