### PR TITLE
Refine registry revert messages and isolate ENS interfaces

### DIFF
--- a/contracts/core/DisputeModule.sol
+++ b/contracts/core/DisputeModule.sol
@@ -27,7 +27,7 @@ contract DisputeModule is Pausable {
         require(registry != address(0), "DisputeModule: registry");
         address current = jobRegistry;
         require(current != address(0), "DisputeModule: registry unset");
-        require(current != registry, "DisputeModule: registry unchanged");
+        require(current != registry, "DisputeModule: same registry");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/core/EchidnaJobRegistryInvariants.sol
+++ b/contracts/core/EchidnaJobRegistryInvariants.sol
@@ -18,6 +18,7 @@ import {ReentrancyGuard} from "../libs/ReentrancyGuard.sol";
 /* solhint-disable func-name-mixedcase */
 
 /// @dev Harness used by Echidna to ensure high-level invariants remain true under fuzzing.
+// solhint-disable-next-line reentrancy -- Echidna harness exercises guarded flows for fuzzing
 contract EchidnaJobRegistryInvariants is ReentrancyGuard {
     uint256 private constant MAX_STAKE = 1e18;
     uint256 private constant WORKER_INITIAL_BALANCE = MAX_STAKE * 100;
@@ -41,6 +42,7 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
     bool private slashBoundsViolated;
     uint256 private expectedFees;
 
+    // solhint-disable-next-line reentrancy -- constructor wires dependencies then seeds actors
     constructor() {
         stakeToken = new MockERC20(
             "Stake Token",
@@ -76,14 +78,14 @@ contract EchidnaJobRegistryInvariants is ReentrancyGuard {
         disputeModule.setJobRegistry(address(jobRegistry));
         reputationEngine.setJobRegistry(address(jobRegistry));
 
+        client = new ClientActor(jobRegistry);
+
         for (uint256 i = 0; i < workers.length; ++i) {
             WorkerActor worker = new WorkerActor(stakeManager, jobRegistry, stakeToken);
             workers[i] = worker;
             stakeToken.transfer(address(worker), WORKER_INITIAL_BALANCE);
             worker.approveStakeManager(type(uint256).max);
         }
-
-        client = new ClientActor(jobRegistry);
     }
 
     /// @notice Deposits a fuzzed amount of stake for a selected worker actor.

--- a/contracts/core/JobRegistry.sol
+++ b/contracts/core/JobRegistry.sol
@@ -308,8 +308,8 @@ contract JobRegistry is Pausable, ReentrancyGuard {
             newDisputeDeadline += disputeExtension;
         }
 
-        require(newRevealDeadline >= newCommitDeadline, "JobRegistry: reveal before commit");
-        require(newDisputeDeadline >= newRevealDeadline, "JobRegistry: dispute before reveal");
+        require(newRevealDeadline >= newCommitDeadline, "JobRegistry: reveal<commit");
+        require(newDisputeDeadline >= newRevealDeadline, "JobRegistry: dispute<reveal");
 
         job.commitDeadline = newCommitDeadline;
         job.revealDeadline = newRevealDeadline;

--- a/contracts/core/ReputationEngine.sol
+++ b/contracts/core/ReputationEngine.sol
@@ -27,7 +27,7 @@ contract ReputationEngine is Pausable {
         require(registry != address(0), "ReputationEngine: registry");
         address current = jobRegistry;
         require(current != address(0), "ReputationEngine: registry unset");
-        require(current != registry, "ReputationEngine: registry unchanged");
+        require(current != registry, "ReputationEngine: same registry");
         jobRegistry = registry;
         emit JobRegistryUpdated(registry);
     }

--- a/contracts/interfaces/IENSNameWrapperLike.sol
+++ b/contracts/interfaces/IENSNameWrapperLike.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IENSNameWrapperLike {
+    function ownerOf(uint256 id) external view returns (address);
+
+    function getData(uint256 id) external view returns (address owner, uint32 fuses, uint64 expiry);
+}

--- a/contracts/interfaces/IENSRegistryLike.sol
+++ b/contracts/interfaces/IENSRegistryLike.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface IENSRegistryLike {
+    function owner(bytes32 node) external view returns (address);
+}

--- a/contracts/libs/EnsOwnership.sol
+++ b/contracts/libs/EnsOwnership.sol
@@ -1,15 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-interface IENSRegistryLike {
-    function owner(bytes32 node) external view returns (address);
-}
-
-interface IENSNameWrapperLike {
-    function ownerOf(uint256 id) external view returns (address);
-
-    function getData(uint256 id) external view returns (address owner, uint32 fuses, uint64 expiry);
-}
+import {IENSRegistryLike} from "../interfaces/IENSRegistryLike.sol";
+import {IENSNameWrapperLike} from "../interfaces/IENSNameWrapperLike.sol";
 
 library EnsOwnership {
     error EnsOwnershipRegistryUnset();

--- a/contracts/libs/MockENSNameWrapper.sol
+++ b/contracts/libs/MockENSNameWrapper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {IENSNameWrapperLike} from "./EnsOwnership.sol";
+import {IENSNameWrapperLike} from "../interfaces/IENSNameWrapperLike.sol";
 
 /// @dev Minimal ENS NameWrapper mock that allows toggling the ownerOf behaviour.
 contract MockENSNameWrapper is IENSNameWrapperLike {

--- a/contracts/libs/MockENSRegistry.sol
+++ b/contracts/libs/MockENSRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import {IENSRegistryLike} from "./EnsOwnership.sol";
+import {IENSRegistryLike} from "../interfaces/IENSRegistryLike.sol";
 
 /// @dev Lightweight ENS registry used for tests that require ownership tracking.
 contract MockENSRegistry is IENSRegistryLike {

--- a/contracts/testing/MockForeverSubdomainRegistrar.sol
+++ b/contracts/testing/MockForeverSubdomainRegistrar.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+contract MockForeverSubdomainRegistrar {
+    struct Name {
+        address pricer;
+        address beneficiary;
+        bool active;
+    }
+
+    mapping(bytes32 => Name) public names;
+
+    event DomainConfigured(bytes32 indexed node, address pricer, address beneficiary, bool active);
+
+    function setName(bytes32 node, address pricer, address beneficiary, bool active) external {
+        names[node] = Name({pricer: pricer, beneficiary: beneficiary, active: active});
+        emit DomainConfigured(node, pricer, beneficiary, active);
+    }
+}

--- a/contracts/testing/MockSubdomainPricer.sol
+++ b/contracts/testing/MockSubdomainPricer.sol
@@ -28,20 +28,3 @@ contract MockSubdomainPricer {
         return (token, quotedPrice);
     }
 }
-
-contract MockForeverSubdomainRegistrar {
-    struct Name {
-        address pricer;
-        address beneficiary;
-        bool active;
-    }
-
-    mapping(bytes32 => Name) public names;
-
-    event DomainConfigured(bytes32 indexed node, address pricer, address beneficiary, bool active);
-
-    function setName(bytes32 node, address pricer, address beneficiary, bool active) external {
-        names[node] = Name({pricer: pricer, beneficiary: beneficiary, active: active});
-        emit DomainConfigured(node, pricer, beneficiary, active);
-    }
-}

--- a/test/disputeModule.test.js
+++ b/test/disputeModule.test.js
@@ -63,7 +63,7 @@ contract('DisputeModule', (accounts) => {
 
     await expectRevert(
       this.module.updateJobRegistry(registry, { from: owner }),
-      'DisputeModule: registry unchanged'
+      'DisputeModule: same registry'
     );
 
     const receipt = await this.module.updateJobRegistry(raiser, { from: owner });

--- a/test/jobRegistry.test.js
+++ b/test/jobRegistry.test.js
@@ -773,12 +773,12 @@ contract('JobRegistry', (accounts) => {
 
     await expectRevert(
       this.jobRegistry.extendJobDeadlines(jobId, 4000, 0, 0, { from: deployer }),
-      'JobRegistry: reveal before commit'
+      'JobRegistry: reveal<commit'
     );
 
     await expectRevert(
       this.jobRegistry.extendJobDeadlines(jobId, 0, 20000, 0, { from: deployer }),
-      'JobRegistry: dispute before reveal'
+      'JobRegistry: dispute<reveal'
     );
 
     const secret = web3.utils.randomHex(32);

--- a/test/reputationEngine.test.js
+++ b/test/reputationEngine.test.js
@@ -63,7 +63,7 @@ contract('ReputationEngine', (accounts) => {
 
     await expectRevert(
       this.engine.updateJobRegistry(registry, { from: owner }),
-      'ReputationEngine: registry unchanged'
+      'ReputationEngine: same registry'
     );
 
     const receipt = await this.engine.updateJobRegistry(worker, { from: owner });


### PR DESCRIPTION
## Summary
- shorten JobRegistry, DisputeModule, and ReputationEngine revert strings so solhint passes and update the associated tests
- extract ENS registry and name wrapper interfaces into contracts/interfaces and point the libraries and mocks at the new modules
- split the old MockSubdomainRegistrar helper into dedicated MockSubdomainPricer and MockForeverSubdomainRegistrar files and document the Echidna harness lint waivers

## Testing
- npm run lint:sol
- npm run config:validate
- npm run config:params -- --no-interactive --dry-run
- npm test
- npm run coverage
- npm run gas
- npm run export:artifacts

------
https://chatgpt.com/codex/tasks/task_e_68d2f6798de08333ac0b2bbd5051f342