### PR TITLE
Add Master Plan narrative for AGI Jobs v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Coverage](https://codecov.io/gh/agi-protocol/AGIJobsv1/branch/main/graph/badge.svg)](https://codecov.io/gh/agi-protocol/AGIJobsv1)
 
-Institutional-grade, ENS-gated job coordination protocol. Contracts only: Solidity, Truffle migrations, tests, CI.
+Institutional-grade, ENS-gated job coordination protocol. Contracts only: Solidity, Truffle migrations, tests, CI. For the strategic narrative behind the rollout, see the [AGI Jobs v1 Master Plan](docs/MasterPlanv1.md).
 
 ## Quickstart
 
@@ -18,6 +18,12 @@ npm run diagnose
 `npm run coverage` enforces a 90% minimum threshold across lines, branches, and functions to match our CI gate. When the CI workflow has access to the repository `CODECOV_TOKEN` secret (for pushes and internal branches), it uploads `coverage/lcov.info` to Codecov so the badge above reflects the latest main-branch run automatically, even for private mirrors; forked pull requests skip the upload without failing the build.
 
 `npm run diagnose` runs a comprehensive readiness audit: it checks Node.js/npm versions against the repository baseline, confirms Hardhat and Truffle are installed, reuses the configuration validator, and flags missing deployment environment variables so non-technical operators can prepare production releases safely.
+
+## Documentation
+
+- [AGI Jobs v1 Master Plan](docs/MasterPlanv1.md) — executive framing for non-technical stakeholders.
+- [Parameter management guide](docs/parameter-management.md) — lifecycle for updating commit/reveal and governance thresholds.
+- [Mainnet deployment simulation](docs/mainnet-deployment-simulation.md) — dry-run transcript covering production readiness.
 
 ### Agent gateway commit/reveal workflow
 

--- a/docs/MasterPlanv1.md
+++ b/docs/MasterPlanv1.md
@@ -1,0 +1,138 @@
+# META-AGENTIC α-AGI JOBS 👁️✨
+
+### The Master Plan: Key to Winning the AI Race 🏆✨
+
+---
+
+## Abstract
+
+We stand at the dawn of a new epoch. **AGI Jobs v1** — the first decentralized marketplace for AGI labor — is more than a platform: it is the _foundation stone_ of a new economic order. By uniting autonomous agents, blockchain coordination, and **meta-agentic orchestration**, AGI Jobs transforms intelligence into a global utility — orchestrated, verified, and rewarded on-chain.
+
+Built from first principles and inspired by physics, **our architecture encodes the laws of intelligent economic dynamics directly into smart contracts**, aligning incentives as rigorously as the Maxwell–Boltzmann distribution aligns particle states. The result: a **self-optimizing, energy-efficient market** where every transaction, every job, every validation becomes part of a civilizational engine — the key to winning the AI race.
+
+---
+
+## Historical Framing
+
+Moments in history stand out as turning points:
+
+- The **steam engine**, which converted thermal energy into industrial power.
+- The **internet**, which converted connectivity into information abundance.
+- The **Turing machine**, which formalized computation itself.
+
+Today, AGI Jobs rises as the next such milestone. By encoding labor, verification, and value distribution for autonomous agents, it creates a **superintelligent labor field** that will underpin how civilization functions in the AGI era. Just as the **Multi-Agent AI DAO (2017)** sketched the vision of autonomous agent coordination on-chain, **AGI Jobs v1 operationalizes it** — in production, at planetary scale.
+
+---
+
+## Scientific Foundations
+
+Our protocol design is grounded in **thermodynamics and statistical physics**, reframing economic interactions as flows of energy and entropy:
+
+- **Maxwell–Boltzmann Distribution**: Agents naturally fall into efficiency bands; the most efficient dominate rewards.
+
+  <div align="center">
+
+  $$P(E)=\frac{1}{Z}\,e^{-E/kT}$$
+
+  </div>
+
+  Here, agent efficiency plays the role of energy $E$, with temperature $T$ modeling systemic volatility.
+
+- **Gibbs Free Energy**: Incentive structures are designed to minimize wasted work, ensuring only useful labor is performed.
+
+  <div align="center">
+
+  $$\Delta G=\Delta H - T\,\Delta S$$
+
+  </div>
+
+  Where enthalpy $(\Delta H)$ represents raw resource allocation, entropy $(\Delta S)$ measures disorder, and $\Delta G$ is the _usable economic output_.
+
+- **Hamiltonian Dynamics**: Each agent’s trajectory in the market is defined by a Hamiltonian:
+
+  <div align="center">
+
+  $$\mathcal{H}(q,p)=\sum_i \frac{p_i^2}{2m_i}+V(q)$$
+
+  </div>
+
+  Encoding the balance of staked value $(p)$, governance inertia $(m)$, and potential economic payoff $V(q)$.
+
+- **Game Theory**: Commitment, staking, and slashing enforce Nash equilibria where cooperation is the only stable outcome.
+
+The result is a **physics-consistent economy** — every inefficiency increases entropy, every cooperative act reduces free energy, every reward aligns with the Pareto frontier.
+
+---
+
+## Platform Architecture
+
+1. **Job Lifecycle (on-chain)**
+   - **Post → Stake → Apply → Validate → Pay**
+   - Escrow enforces fairness, commit–reveal prevents collusion, and IPFS-secured artifacts guarantee verifiable deliverables.
+
+2. **Meta-Agentic Orchestration**
+   - Agents not only solve tasks but spawn sub-agents, critique outputs, and recursively self-improve.
+   - Second-order agency creates a **flywheel of intelligence**: each job solved enriches the network’s capability.
+
+3. **Thermodynamic Incentive Layer**
+   - Energy metrics (gas, compute cycles, latency) are logged on-chain.
+   - Rewards follow Boltzmann weighting — efficient agents are exponentially advantaged.
+
+4. **Reputation & Provenance**
+   - Completion mints non-transferable NFTs (proof-of-work certificates).
+   - Provenance DAGs link artifacts into a chain of credit and yield distribution.
+
+---
+
+## Tokenomics — $AGIALPHA 👁️✨
+
+- **Medium of Exchange**: All jobs priced, staked, and paid in $AGIALPHA.
+- **Skin in the Game**: Agents must stake before bidding; validators stake before voting.
+- **Thermodynamic Rewards**: Reward allocation weighted by efficiency and entropy reduction.
+- **Deflationary Mechanics**: % burn on each transaction, binding token value to network growth.
+
+---
+
+## Governance — α-AGI Governance
+
+Governance is not an afterthought; it is **α-phase AGI governance**:
+
+- **Quadratic Voting**: Prevents plutocracy, balances minority voices.
+- **Timelocked Upgrades**: Every proposal faces a mandatory cool-off for auditability.
+- **Antifragility**: Adversarial shocks increase systemic robustness; slashing and audit logs continuously refine the protocol.
+- **Human Oversight Anchors**: Validators and dispute modules preserve human agency within the loop.
+
+---
+
+## Strategic Positioning: Key to Winning the AI Race 🏆✨
+
+The AI race will not be won by a single model but by the **infrastructure that coordinates all models**. AGI Jobs is that infrastructure:
+
+- **First-Mover Advantage**: The first credible AGI jobs market defines the rules.
+- **Network Effects**: More jobs → more agents → more jobs, compounding into dominance.
+- **Civilizational Value**: With potential to unlock **$15 quadrillion in new wealth**, the platform is positioned as the _superintelligent economic engine_ of the AGI age.
+
+---
+
+## Forward Path — Solana & Beyond
+
+- **Ethereum Layer**: Core security, ENS-based identities (`*.agi.eth`), $AGIALPHA staking.
+- **Solana Integration**: High-speed, low-cost execution for microtasks and real-time coordination.
+- **Cross-Chain Future**: Omni-chain AGI Jobs, with Ethereum anchoring trust and Solana scaling throughput.
+
+---
+
+## Call to Action
+
+This is **humanity’s Apollo program for intelligence**.
+
+We invite:
+
+- **Builders**: Code the contracts, expand the marketplace.
+- **Agents**: Plug in your intelligence, earn $AGIALPHA.
+- **Employers**: Post your jobs, harness the global swarm.
+- **Nations & Institutions**: Build on AGI Jobs to secure your place in the coming economic order.
+
+History will remember those who act now. **AGI Jobs v1 is the key to winning the AI race 🏆✨ — not by inches, but by leaps.**
+
+---


### PR DESCRIPTION
## Summary
- import the AGI Jobs v1 master plan narrative into docs with updated version references
- link the strategic narrative from the README introduction and surface it inside a dedicated documentation section
- format the touched markdown files with Prettier for consistent presentation

## Testing
- npx prettier --write README.md docs/MasterPlanv1.md

------
https://chatgpt.com/codex/tasks/task_e_68d2ff3fe7cc8333b7040d0ce9259cce