### PR TITLE
Add owner task utilities and Hardhat workflows for FeePool and StakeManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,36 @@ Edit configuration files under `config/` to match the deployment environment:
   broadcasting, and emits a dry-run transaction summary when `--execute` is omitted.
 - `npx hardhat identity-registry:emergency-status --network <network> --addresses '["0x..."]'` reports whether the provided
   addresses currently hold emergency privileges, while `npx hardhat identity-registry:set-emergency --network <network>
---allow '0x...,0x...' --plan-out ./plan.json` produces a Safe-ready sequence of `setEmergencyAccess` calls that can be
+  --allow '0x...,0x...' --plan-out ./plan.json` produces a Safe-ready sequence of `setEmergencyAccess` calls that can be
   executed with `--execute --from 0xOwner` once reviewed.
+
+### FeePool Hardhat tasks
+
+- `npx hardhat fee-pool:status --network <network>` prints the FeePool owner, burn destination, configured JobRegistry, and
+  fee token metadata, including the current token balance and recorded total fees.
+- `npx hardhat fee-pool:set-registry --network <network> --registry 0xRegistry` plans the one-time registry wiring and writes
+  Safe-ready JSON when `--plan-out ./plan.json` is supplied; append `--execute --from 0xOwner` to broadcast once ready.
+- `npx hardhat fee-pool:update-registry --network <network> --registry 0xNew` enforces pause-free migration guardrails and
+  emits the same plan summaries before optionally calling `updateJobRegistry` with `--execute`.
+- `npx hardhat fee-pool:update-burn --network <network> --burn 0xDestination` updates the burn recipient with dry-run metadata
+  that highlights the previous address and the new target.
+- `npx hardhat fee-pool:burn --network <network>` defaults to a dry run that reports the balance slated for burning; provide
+  `--execute --from 0xOwner` to submit the transfer when a positive balance is available.
+
+### StakeManager Hardhat tasks
+
+- `npx hardhat stake-manager:status --network <network>` displays owner, JobRegistry, fee recipient, pause state, stake token
+  metadata, and the contract's token balance with human-friendly formatting.
+- `npx hardhat stake-manager:set-registry --network <network> --registry 0xRegistry` performs the initial registry wiring and
+  produces JSON plans via `--plan-out`; re-run with `--execute --from 0xOwner` after confirming the dry-run output.
+- `npx hardhat stake-manager:update-registry --network <network> --registry 0xNew` validates the manager is paused before
+  generating an `updateJobRegistry` payload and optionally broadcasting it.
+- `npx hardhat stake-manager:set-fee-recipient --network <network> --recipient 0xDestination` coordinates recipient changes,
+  echoing both the previous and proposed destinations during dry runs.
+- `npx hardhat stake-manager:pause --network <network>` and `npx hardhat stake-manager:unpause --network <network>` default to
+  dry runs that confirm the current state and emit calldata plans before any transaction is sent.
+- `npx hardhat stake-manager:emergency-release --network <network> --account 0xWorker --amount <raw>` helps governance unlock
+  specific worker balances with Safe-ready summaries and optional live broadcasts via `--execute --from 0xOwner`.
 
 ### IdentityRegistry ENS console
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 require('@nomiclabs/hardhat-truffle5');
 require('solidity-coverage');
 require('./tasks/jobRegistry');
+require('./tasks/feePool');
+require('./tasks/stakeManager');
 
 const { MNEMONIC, RPC_SEPOLIA, RPC_MAINNET } = process.env;
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "config:profiles": "node scripts/config-profile-manager.js",
     "identity:console": "npx truffle exec scripts/identity-registry-console.js --network ${NETWORK:-development}",
     "identity:emergency": "npx truffle exec scripts/identity-registry-emergency.js --network ${NETWORK:-development}",
+    "fee:status": "npx hardhat fee-pool:status --network ${NETWORK:-development}",
+    "stake:status": "npx hardhat stake-manager:status --network ${NETWORK:-development}",
     "prepare": "husky install",
     "hardhat:test": "node scripts/run-tests.js",
     "config:console": "npx truffle exec scripts/job-registry-config-console.js --network ${NETWORK:-development}",

--- a/scripts/lib/owner-task-utils.js
+++ b/scripts/lib/owner-task-utils.js
@@ -1,0 +1,289 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { serializeForJson } = require('./json-utils');
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const ERC20_METADATA_ABI = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'name',
+    outputs: [{ name: '', type: 'string' }],
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'symbol',
+    outputs: [{ name: '', type: 'string' }],
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'decimals',
+    outputs: [{ name: '', type: 'uint8' }],
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [{ name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: '', type: 'uint256' }],
+    type: 'function',
+  },
+];
+
+function toChecksum(web3Instance, address) {
+  if (!address) {
+    return null;
+  }
+
+  const candidate = String(address);
+  if (
+    !web3Instance ||
+    !web3Instance.utils ||
+    typeof web3Instance.utils.toChecksumAddress !== 'function'
+  ) {
+    return candidate;
+  }
+
+  try {
+    return web3Instance.utils.toChecksumAddress(candidate);
+  } catch (error) {
+    return candidate;
+  }
+}
+
+function isZeroAddress(address) {
+  if (!address) {
+    return true;
+  }
+  return String(address).toLowerCase() === ZERO_ADDRESS;
+}
+
+function formatAddress(web3Instance, address) {
+  if (!address || isZeroAddress(address)) {
+    return '(unset)';
+  }
+  return toChecksum(web3Instance, address);
+}
+
+function ensureAddress(web3Instance, candidate, label) {
+  if (!candidate) {
+    throw new Error(`${label} address is required.`);
+  }
+
+  if (!web3Instance || !web3Instance.utils || typeof web3Instance.utils.isAddress !== 'function') {
+    return candidate;
+  }
+
+  if (!web3Instance.utils.isAddress(candidate)) {
+    throw new Error(`${label} address is invalid: ${candidate}`);
+  }
+
+  return toChecksum(web3Instance, candidate);
+}
+
+function ensureUint256(value, label) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`${label} value is required.`);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(`${label} must be a non-negative integer.`);
+    }
+    return Math.trunc(value).toString();
+  }
+
+  const stringified = String(value).trim();
+  if (!/^\d+$/.test(stringified)) {
+    throw new Error(`${label} must be provided as a non-negative integer.`);
+  }
+
+  return stringified;
+}
+
+async function resolveSender(hre, explicit) {
+  if (explicit) {
+    return ensureAddress(hre.web3, explicit, '--from');
+  }
+
+  const accounts = await hre.web3.eth.getAccounts();
+  if (!accounts || accounts.length === 0) {
+    throw new Error(
+      'No unlocked accounts are available. Provide --from to specify the transaction sender.'
+    );
+  }
+
+  return ensureAddress(hre.web3, accounts[0], 'Default account');
+}
+
+function ensureOwner(sender, owner, contractLabel) {
+  if (!owner || isZeroAddress(owner)) {
+    throw new Error(`${contractLabel} owner is not configured on-chain.`);
+  }
+
+  if (sender.toLowerCase() !== owner.toLowerCase()) {
+    throw new Error(
+      `Sender ${sender} is not the ${contractLabel} owner (${owner}). ` +
+        'Provide --from with the owner account or forward the generated plan through the owner multisig.'
+    );
+  }
+}
+
+function buildCallSummary({ action, method, args, metadata, contractAddress, sender, callData }) {
+  return {
+    action,
+    method,
+    args: serializeForJson(args),
+    metadata: serializeForJson(metadata || {}),
+    call: {
+      to: contractAddress,
+      data: callData,
+      value: '0',
+      from: sender || null,
+    },
+  };
+}
+
+function printPlanSummary(summary) {
+  console.log('Planned transaction:');
+  console.log(`  action: ${summary.action}`);
+  console.log(`  to: ${summary.call.to}`);
+  console.log(`  method: ${summary.method}`);
+  console.log(`  args: ${JSON.stringify(summary.args, null, 2)}`);
+  console.log(`  data: ${summary.call.data}`);
+  if (summary.metadata && Object.keys(summary.metadata).length > 0) {
+    console.log(`  metadata: ${JSON.stringify(summary.metadata, null, 2)}`);
+  }
+}
+
+function maybeWriteSummary(outputPath, summary) {
+  if (!outputPath) {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  return resolvedPath;
+}
+
+async function callOptional(contract, method, args = []) {
+  if (!contract || !contract.methods || typeof contract.methods[method] !== 'function') {
+    return null;
+  }
+
+  try {
+    return await contract.methods[method](...args).call();
+  } catch (error) {
+    return null;
+  }
+}
+
+async function fetchErc20Metadata(web3Instance, tokenAddress) {
+  if (!tokenAddress || isZeroAddress(tokenAddress)) {
+    return null;
+  }
+
+  const contract = new web3Instance.eth.Contract(ERC20_METADATA_ABI, tokenAddress);
+  const [name, symbol, decimalsRaw] = await Promise.all([
+    callOptional(contract, 'name'),
+    callOptional(contract, 'symbol'),
+    callOptional(contract, 'decimals'),
+  ]);
+
+  let decimals = null;
+  if (decimalsRaw !== null && decimalsRaw !== undefined) {
+    try {
+      decimals = Number(decimalsRaw);
+      if (!Number.isFinite(decimals)) {
+        decimals = null;
+      }
+    } catch (error) {
+      decimals = null;
+    }
+  }
+
+  return {
+    name: name || null,
+    symbol: symbol || null,
+    decimals,
+  };
+}
+
+async function readTokenBalance(web3Instance, tokenAddress, holder) {
+  if (!tokenAddress || isZeroAddress(tokenAddress) || !holder) {
+    return null;
+  }
+
+  const contract = new web3Instance.eth.Contract(ERC20_METADATA_ABI, tokenAddress);
+  const balance = await callOptional(contract, 'balanceOf', [holder]);
+  return balance !== null && balance !== undefined ? String(balance) : null;
+}
+
+function formatTokenMetadata(metadata) {
+  if (!metadata) {
+    return 'unavailable';
+  }
+
+  const parts = [];
+  if (metadata.name) {
+    parts.push(metadata.name);
+  }
+  if (metadata.symbol) {
+    parts.push(`symbol ${metadata.symbol}`);
+  }
+  if (metadata.decimals !== null && metadata.decimals !== undefined) {
+    parts.push(`${metadata.decimals} decimals`);
+  }
+  if (parts.length === 0) {
+    return 'unavailable';
+  }
+  return parts.join(', ');
+}
+
+function formatTokenAmount(rawAmount, decimals, precision = 6) {
+  if (rawAmount === null || rawAmount === undefined) {
+    return 'unavailable';
+  }
+
+  const normalized = BigInt(rawAmount);
+  if (decimals === null || decimals === undefined || decimals < 0) {
+    return normalized.toString();
+  }
+
+  const scale = BigInt(10) ** BigInt(decimals);
+  const whole = normalized / scale;
+  const fraction = normalized % scale;
+  if (fraction === 0n) {
+    return `${normalized.toString()} (${whole.toString()})`;
+  }
+
+  const padded = fraction.toString().padStart(decimals, '0');
+  const trimmed = padded.replace(/0+$/, '');
+  const truncated = trimmed.length > precision ? `${trimmed.slice(0, precision)}…` : trimmed;
+  return `${normalized.toString()} (${whole.toString()}.${truncated})`;
+}
+
+module.exports = {
+  buildCallSummary,
+  ensureAddress,
+  ensureOwner,
+  ensureUint256,
+  fetchErc20Metadata,
+  formatAddress,
+  formatTokenAmount,
+  formatTokenMetadata,
+  maybeWriteSummary,
+  printPlanSummary,
+  readTokenBalance,
+  resolveSender,
+  toChecksum,
+};

--- a/tasks/feePool.js
+++ b/tasks/feePool.js
@@ -1,0 +1,368 @@
+'use strict';
+
+const { task, types } = require('hardhat/config');
+
+const {
+  buildCallSummary,
+  ensureAddress,
+  ensureOwner,
+  fetchErc20Metadata,
+  formatAddress,
+  formatTokenAmount,
+  formatTokenMetadata,
+  maybeWriteSummary,
+  printPlanSummary,
+  readTokenBalance,
+  resolveSender,
+} = require('../scripts/lib/owner-task-utils');
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+async function resolveFeePool(hre, explicitAddress) {
+  const FeePool = hre.artifacts.require('FeePool');
+  if (explicitAddress) {
+    return FeePool.at(explicitAddress);
+  }
+  return FeePool.deployed();
+}
+
+function describeNetwork(hre) {
+  const { name } = hre.network;
+  return name || 'unknown';
+}
+
+function buildStatusSummary({
+  hre,
+  feePool,
+  owner,
+  jobRegistry,
+  burnAddress,
+  feeToken,
+  totalFeesRecorded,
+  tokenMetadata,
+  tokenBalance,
+}) {
+  const summary = {
+    network: describeNetwork(hre),
+    feePool: feePool.address,
+    owner,
+    jobRegistry,
+    burnAddress,
+    feeToken,
+    totalFeesRecorded,
+  };
+
+  if (tokenMetadata) {
+    summary.feeTokenMetadata = tokenMetadata;
+  }
+
+  if (tokenBalance !== null && tokenBalance !== undefined) {
+    summary.tokenBalance = tokenBalance;
+    if (tokenMetadata && tokenMetadata.decimals !== null && tokenMetadata.decimals !== undefined) {
+      summary.tokenBalanceFormatted = formatTokenAmount(tokenBalance, tokenMetadata.decimals);
+    }
+  }
+
+  return summary;
+}
+
+function printStatus(summary, hre) {
+  console.log(`FeePool status on ${summary.network}:`);
+  console.log(`- Address: ${formatAddress(hre.web3, summary.feePool)}`);
+  console.log(`- Owner: ${formatAddress(hre.web3, summary.owner)}`);
+  console.log(`- Job registry: ${formatAddress(hre.web3, summary.jobRegistry)}`);
+  console.log(`- Burn address: ${formatAddress(hre.web3, summary.burnAddress)}`);
+  console.log(`- Fee token: ${formatAddress(hre.web3, summary.feeToken)}`);
+  if (summary.feeTokenMetadata) {
+    console.log(`  Token metadata: ${formatTokenMetadata(summary.feeTokenMetadata)}`);
+  } else {
+    console.log('  Token metadata: unavailable');
+  }
+  console.log(`- Total fees recorded: ${summary.totalFeesRecorded}`);
+  if (summary.tokenBalance !== undefined) {
+    const formatted = summary.tokenBalanceFormatted || summary.tokenBalance;
+    console.log(`- Current token balance: ${formatted}`);
+  }
+}
+
+task('fee-pool:status', 'Prints the FeePool configuration snapshot.')
+  .addOptionalParam('feePool', 'Address of the FeePool contract', undefined, types.string)
+  .addFlag('json', 'Emit the summary as JSON for automation pipelines.')
+  .setAction(async (args, hre) => {
+    const feePool = await resolveFeePool(hre, args.feePool);
+    const [owner, jobRegistry, burnAddress, feeToken, totalFeesRecordedRaw] = await Promise.all([
+      feePool.owner(),
+      feePool.jobRegistry(),
+      feePool.burnAddress(),
+      feePool.feeToken(),
+      feePool.totalFeesRecorded(),
+    ]);
+
+    const tokenMetadata = await fetchErc20Metadata(hre.web3, feeToken);
+    const tokenBalance = await readTokenBalance(hre.web3, feeToken, feePool.address);
+    const totalFeesRecorded = totalFeesRecordedRaw.toString();
+
+    const summary = buildStatusSummary({
+      hre,
+      feePool,
+      owner,
+      jobRegistry,
+      burnAddress,
+      feeToken,
+      totalFeesRecorded,
+      tokenMetadata,
+      tokenBalance,
+    });
+
+    if (args.json) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    printStatus(summary, hre);
+  });
+
+task('fee-pool:set-registry', 'Initializes the authorized JobRegistry for the FeePool.')
+  .addOptionalParam('feePool', 'Address of the FeePool contract', undefined, types.string)
+  .addParam('registry', 'Address of the JobRegistry contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const feePool = await resolveFeePool(hre, args.feePool);
+    const owner = await feePool.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'FeePool');
+
+    const registryAddress = ensureAddress(hre.web3, args.registry, '--registry');
+    const currentRegistry = await feePool.jobRegistry();
+    if (currentRegistry && currentRegistry !== ZERO_ADDRESS) {
+      throw new Error(
+        `FeePool already has a job registry configured (${currentRegistry}). Use fee-pool:update-registry instead.`
+      );
+    }
+
+    const callData = feePool.contract.methods.setJobRegistry(registryAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'fee-pool:setJobRegistry',
+      method: 'setJobRegistry(address)',
+      args: [registryAddress],
+      metadata: {
+        previousRegistry: currentRegistry,
+        newRegistry: registryAddress,
+      },
+      contractAddress: feePool.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await feePool.setJobRegistry(registryAddress, { from: sender });
+    console.log(`Transaction submitted. FeePool job registry set to ${registryAddress}.`);
+  });
+
+task('fee-pool:update-registry', 'Reassigns the JobRegistry authorized to report fees.')
+  .addOptionalParam('feePool', 'Address of the FeePool contract', undefined, types.string)
+  .addParam('registry', 'Address of the new JobRegistry contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const feePool = await resolveFeePool(hre, args.feePool);
+    const owner = await feePool.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'FeePool');
+
+    const registryAddress = ensureAddress(hre.web3, args.registry, '--registry');
+    const currentRegistry = await feePool.jobRegistry();
+    if (!currentRegistry || currentRegistry === ZERO_ADDRESS) {
+      throw new Error(
+        'FeePool job registry is not configured yet. Use fee-pool:set-registry first.'
+      );
+    }
+    if (currentRegistry.toLowerCase() === registryAddress.toLowerCase()) {
+      throw new Error('FeePool job registry already matches the provided address.');
+    }
+
+    const callData = feePool.contract.methods.updateJobRegistry(registryAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'fee-pool:updateJobRegistry',
+      method: 'updateJobRegistry(address)',
+      args: [registryAddress],
+      metadata: {
+        previousRegistry: currentRegistry,
+        newRegistry: registryAddress,
+      },
+      contractAddress: feePool.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await feePool.updateJobRegistry(registryAddress, { from: sender });
+    console.log(`Transaction submitted. FeePool job registry updated to ${registryAddress}.`);
+  });
+
+task('fee-pool:update-burn', 'Updates the burn destination for accumulated protocol fees.')
+  .addOptionalParam('feePool', 'Address of the FeePool contract', undefined, types.string)
+  .addParam('burn', 'Address of the new burn destination', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const feePool = await resolveFeePool(hre, args.feePool);
+    const owner = await feePool.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'FeePool');
+
+    const newBurnAddress = ensureAddress(hre.web3, args.burn, '--burn');
+    const currentBurnAddress = await feePool.burnAddress();
+    if (currentBurnAddress.toLowerCase() === newBurnAddress.toLowerCase()) {
+      throw new Error('FeePool burn address already matches the provided destination.');
+    }
+
+    const callData = feePool.contract.methods.updateBurnAddress(newBurnAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'fee-pool:updateBurnAddress',
+      method: 'updateBurnAddress(address)',
+      args: [newBurnAddress],
+      metadata: {
+        previousBurnAddress: currentBurnAddress,
+        newBurnAddress,
+      },
+      contractAddress: feePool.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await feePool.updateBurnAddress(newBurnAddress, { from: sender });
+    console.log(`Transaction submitted. FeePool burn address updated to ${newBurnAddress}.`);
+  });
+
+task('fee-pool:burn', 'Transfers the accumulated fee token balance to the configured burn address.')
+  .addOptionalParam('feePool', 'Address of the FeePool contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const feePool = await resolveFeePool(hre, args.feePool);
+    const owner = await feePool.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'FeePool');
+
+    const feeToken = await feePool.feeToken();
+    const burnAddress = await feePool.burnAddress();
+    const tokenMetadata = await fetchErc20Metadata(hre.web3, feeToken);
+    const tokenBalance = await readTokenBalance(hre.web3, feeToken, feePool.address);
+
+    if (tokenBalance === null) {
+      console.log(
+        'Warning: Unable to read the FeePool token balance. The transaction may revert if nothing is available.'
+      );
+    } else if (BigInt(tokenBalance) === 0n) {
+      throw new Error('FeePool balance is zero. Burning would revert.');
+    }
+
+    const callData = feePool.contract.methods.burnAccumulatedFees().encodeABI();
+    const plan = buildCallSummary({
+      action: 'fee-pool:burnAccumulatedFees',
+      method: 'burnAccumulatedFees()',
+      args: [],
+      metadata: {
+        burnAddress,
+        tokenBalance,
+        tokenBalanceFormatted:
+          tokenBalance !== null && tokenMetadata && tokenMetadata.decimals !== null
+            ? formatTokenAmount(tokenBalance, tokenMetadata.decimals)
+            : tokenBalance,
+      },
+      contractAddress: feePool.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await feePool.burnAccumulatedFees({ from: sender });
+    console.log('Transaction submitted. FeePool burn executed.');
+  });

--- a/tasks/stakeManager.js
+++ b/tasks/stakeManager.js
@@ -1,0 +1,501 @@
+'use strict';
+
+const { task, types } = require('hardhat/config');
+
+const {
+  buildCallSummary,
+  ensureAddress,
+  ensureOwner,
+  ensureUint256,
+  fetchErc20Metadata,
+  formatAddress,
+  formatTokenAmount,
+  formatTokenMetadata,
+  maybeWriteSummary,
+  printPlanSummary,
+  readTokenBalance,
+  resolveSender,
+} = require('../scripts/lib/owner-task-utils');
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+async function resolveStakeManager(hre, explicitAddress) {
+  const StakeManager = hre.artifacts.require('StakeManager');
+  if (explicitAddress) {
+    return StakeManager.at(explicitAddress);
+  }
+  return StakeManager.deployed();
+}
+
+function describeNetwork(hre) {
+  const { name } = hre.network;
+  return name || 'unknown';
+}
+
+function normalizeNumber(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value.toNumber === 'function') {
+    return value.toNumber();
+  }
+  const stringified = value.toString();
+  if (/^\d+$/.test(stringified)) {
+    return Number(stringified);
+  }
+  return stringified;
+}
+
+function buildStatusSummary({
+  hre,
+  stakeManager,
+  owner,
+  jobRegistry,
+  feeRecipient,
+  paused,
+  stakeToken,
+  stakeTokenDecimals,
+  tokenMetadata,
+  tokenBalance,
+}) {
+  const summary = {
+    network: describeNetwork(hre),
+    stakeManager: stakeManager.address,
+    owner,
+    jobRegistry,
+    feeRecipient,
+    paused,
+    stakeToken,
+    stakeTokenDecimals,
+  };
+
+  if (tokenMetadata) {
+    summary.stakeTokenMetadata = tokenMetadata;
+  }
+
+  if (tokenBalance !== null && tokenBalance !== undefined) {
+    summary.contractBalance = tokenBalance;
+    if (tokenMetadata && tokenMetadata.decimals !== null && tokenMetadata.decimals !== undefined) {
+      summary.contractBalanceFormatted = formatTokenAmount(tokenBalance, tokenMetadata.decimals);
+    }
+  }
+
+  return summary;
+}
+
+function printStatus(summary, hre) {
+  console.log(`StakeManager status on ${summary.network}:`);
+  console.log(`- Address: ${formatAddress(hre.web3, summary.stakeManager)}`);
+  console.log(`- Owner: ${formatAddress(hre.web3, summary.owner)}`);
+  console.log(`- Job registry: ${formatAddress(hre.web3, summary.jobRegistry)}`);
+  console.log(`- Fee recipient: ${formatAddress(hre.web3, summary.feeRecipient)}`);
+  console.log(`- Paused: ${Boolean(summary.paused)}`);
+  console.log(`- Stake token: ${formatAddress(hre.web3, summary.stakeToken)}`);
+  if (summary.stakeTokenMetadata) {
+    console.log(`  Token metadata: ${formatTokenMetadata(summary.stakeTokenMetadata)}`);
+  } else {
+    console.log('  Token metadata: unavailable');
+  }
+  console.log(`- Stake token decimals (cached): ${summary.stakeTokenDecimals}`);
+  if (summary.contractBalance !== undefined) {
+    const formatted = summary.contractBalanceFormatted || summary.contractBalance;
+    console.log(`- Current contract balance: ${formatted}`);
+  }
+}
+
+task('stake-manager:status', 'Prints the StakeManager configuration snapshot.')
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addFlag('json', 'Emit the summary as JSON for automation pipelines.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const [owner, jobRegistry, feeRecipient, paused, stakeToken, stakeTokenDecimalsRaw] =
+      await Promise.all([
+        stakeManager.owner(),
+        stakeManager.jobRegistry(),
+        stakeManager.feeRecipient(),
+        stakeManager.paused(),
+        stakeManager.stakeToken(),
+        stakeManager.stakeTokenDecimals(),
+      ]);
+
+    const stakeTokenDecimals = normalizeNumber(stakeTokenDecimalsRaw);
+    const tokenMetadata = await fetchErc20Metadata(hre.web3, stakeToken);
+    const tokenBalance = await readTokenBalance(hre.web3, stakeToken, stakeManager.address);
+
+    const summary = buildStatusSummary({
+      hre,
+      stakeManager,
+      owner,
+      jobRegistry,
+      feeRecipient,
+      paused,
+      stakeToken,
+      stakeTokenDecimals,
+      tokenMetadata,
+      tokenBalance,
+    });
+
+    if (args.json) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    printStatus(summary, hre);
+  });
+
+task('stake-manager:set-registry', 'Initializes the JobRegistry authorized to manage stake locks.')
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addParam('registry', 'Address of the JobRegistry contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const owner = await stakeManager.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'StakeManager');
+
+    const registryAddress = ensureAddress(hre.web3, args.registry, '--registry');
+    const currentRegistry = await stakeManager.jobRegistry();
+    if (currentRegistry && currentRegistry !== ZERO_ADDRESS) {
+      throw new Error(
+        `StakeManager already has a job registry configured (${currentRegistry}). Use stake-manager:update-registry instead.`
+      );
+    }
+
+    const callData = stakeManager.contract.methods.setJobRegistry(registryAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'stake-manager:setJobRegistry',
+      method: 'setJobRegistry(address)',
+      args: [registryAddress],
+      metadata: {
+        previousRegistry: currentRegistry,
+        newRegistry: registryAddress,
+      },
+      contractAddress: stakeManager.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await stakeManager.setJobRegistry(registryAddress, { from: sender });
+    console.log(`Transaction submitted. StakeManager job registry set to ${registryAddress}.`);
+  });
+
+task('stake-manager:update-registry', 'Reassigns the JobRegistry authorized to manage stake locks.')
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addParam('registry', 'Address of the replacement JobRegistry contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const owner = await stakeManager.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'StakeManager');
+
+    const registryAddress = ensureAddress(hre.web3, args.registry, '--registry');
+    const currentRegistry = await stakeManager.jobRegistry();
+    if (!currentRegistry || currentRegistry === ZERO_ADDRESS) {
+      throw new Error(
+        'StakeManager job registry is not configured yet. Use stake-manager:set-registry first.'
+      );
+    }
+    if (currentRegistry.toLowerCase() === registryAddress.toLowerCase()) {
+      throw new Error('StakeManager job registry already matches the provided address.');
+    }
+
+    const paused = await stakeManager.paused();
+    if (!paused) {
+      throw new Error(
+        'StakeManager must be paused before calling updateJobRegistry. Invoke stake-manager:pause first.'
+      );
+    }
+
+    const callData = stakeManager.contract.methods.updateJobRegistry(registryAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'stake-manager:updateJobRegistry',
+      method: 'updateJobRegistry(address)',
+      args: [registryAddress],
+      metadata: {
+        previousRegistry: currentRegistry,
+        newRegistry: registryAddress,
+      },
+      contractAddress: stakeManager.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await stakeManager.updateJobRegistry(registryAddress, { from: sender });
+    console.log(`Transaction submitted. StakeManager job registry updated to ${registryAddress}.`);
+  });
+
+task(
+  'stake-manager:set-fee-recipient',
+  'Sets the destination that receives slashed stake proceeds.'
+)
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addParam('recipient', 'Address of the fee recipient', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const owner = await stakeManager.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'StakeManager');
+
+    const recipientAddress = ensureAddress(hre.web3, args.recipient, '--recipient');
+    const currentRecipient = await stakeManager.feeRecipient();
+    if (currentRecipient && currentRecipient.toLowerCase() === recipientAddress.toLowerCase()) {
+      throw new Error('StakeManager fee recipient already matches the provided address.');
+    }
+
+    const callData = stakeManager.contract.methods.setFeeRecipient(recipientAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'stake-manager:setFeeRecipient',
+      method: 'setFeeRecipient(address)',
+      args: [recipientAddress],
+      metadata: {
+        previousRecipient: currentRecipient,
+        newRecipient: recipientAddress,
+      },
+      contractAddress: stakeManager.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await stakeManager.setFeeRecipient(recipientAddress, { from: sender });
+    console.log(
+      `Transaction submitted. StakeManager fee recipient updated to ${recipientAddress}.`
+    );
+  });
+
+task('stake-manager:pause', 'Pauses StakeManager deposits and withdrawals.')
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const owner = await stakeManager.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'StakeManager');
+
+    const paused = await stakeManager.paused();
+    if (paused) {
+      throw new Error('StakeManager is already paused.');
+    }
+
+    const callData = stakeManager.contract.methods.pause().encodeABI();
+    const plan = buildCallSummary({
+      action: 'stake-manager:pause',
+      method: 'pause()',
+      args: [],
+      metadata: {},
+      contractAddress: stakeManager.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await stakeManager.pause({ from: sender });
+    console.log('Transaction submitted. StakeManager paused.');
+  });
+
+task('stake-manager:unpause', 'Resumes StakeManager deposits and withdrawals.')
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const owner = await stakeManager.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'StakeManager');
+
+    const paused = await stakeManager.paused();
+    if (!paused) {
+      throw new Error('StakeManager is not paused.');
+    }
+
+    const callData = stakeManager.contract.methods.unpause().encodeABI();
+    const plan = buildCallSummary({
+      action: 'stake-manager:unpause',
+      method: 'unpause()',
+      args: [],
+      metadata: {},
+      contractAddress: stakeManager.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await stakeManager.unpause({ from: sender });
+    console.log('Transaction submitted. StakeManager unpaused.');
+  });
+
+task(
+  'stake-manager:emergency-release',
+  'Invokes the owner emergency release to unlock staked funds without registry interaction.'
+)
+  .addOptionalParam('stakeManager', 'Address of the StakeManager contract', undefined, types.string)
+  .addParam('account', 'Address whose locked stake will be released', undefined, types.string)
+  .addParam('amount', 'Amount of stake to release (raw token units)', undefined, types.string)
+  .addOptionalParam(
+    'from',
+    'Sender address. Defaults to the first unlocked account.',
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    'planOut',
+    'Optional path to persist the call summary JSON.',
+    undefined,
+    types.string
+  )
+  .addFlag('execute', 'Broadcast the transaction instead of performing a dry run.')
+  .setAction(async (args, hre) => {
+    const stakeManager = await resolveStakeManager(hre, args.stakeManager);
+    const owner = await stakeManager.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'StakeManager');
+
+    const accountAddress = ensureAddress(hre.web3, args.account, '--account');
+    const amount = ensureUint256(args.amount, '--amount');
+
+    const callData = stakeManager.contract.methods
+      .emergencyRelease(accountAddress, amount)
+      .encodeABI();
+    const plan = buildCallSummary({
+      action: 'stake-manager:emergencyRelease',
+      method: 'emergencyRelease(address,uint256)',
+      args: [accountAddress, amount],
+      metadata: {
+        account: accountAddress,
+        amount,
+      },
+      contractAddress: stakeManager.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await stakeManager.emergencyRelease(accountAddress, amount, { from: sender });
+    console.log(`Transaction submitted. Emergency release initiated for ${accountAddress}.`);
+  });


### PR DESCRIPTION
## Summary
- add shared Hardhat owner-task utilities for address validation, plan writing, and ERC-20 metadata helpers
- expose FeePool status and management commands (registry rotation, burn configuration, burn execution)
- expose StakeManager status, registry, fee-recipient, pause, and emergency release commands and document new workflows
- document the new commands in the README and provide npm shortcuts for quick status checks

## Testing
- `npm run lint:sol`
- `npm run build`
- `npm run test`
- `npm run coverage`
- `npm run config:validate`


------
https://chatgpt.com/codex/tasks/task_e_68d40d5628bc8333a289f372748f0256