### PR TITLE
Add DisputeModule and ValidationModule Hardhat task suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ All notable changes to this project will be documented in this file.
   sequential broadcast support for multi-step updates.
 - Hardhat emergency management tasks (`identity-registry:emergency-status` / `identity-registry:set-emergency`) that surface
   allow-list drift, generate multisig payloads, and enforce owner-only execution before broadcasting.
+- Hardhat `dispute-module:*` task suite for registry wiring, pause management, and Safe-ready plan exports with owner
+  enforcement.
+- Hardhat `validation-module:*` tooling that normalizes rule identifiers (including file-based inputs), generates Safe-ready
+  payloads, and blocks no-op broadcasts unless `--force` is supplied.
+
+### Fixed
+
+- Ensure Hardhat eagerly loads the IdentityRegistry task definitions so the documented `identity-registry:*` CLI commands work
+  without requiring manual imports in downstream scripts.
 
 ## [1.1.0] - 2025-02-21
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Edit configuration files under `config/` to match the deployment environment:
 ### IdentityRegistry Hardhat tasks
 
 - `npx hardhat identity-registry:status --network <network>` prints the on-chain ENS configuration, automatically compares it
-  against the repository config profile (or an explicit `--config` path), and highlights any drift together with optional
+  against the repository config profile (or an explicit `--config-path` flag), and highlights any drift together with optional
   override previews such as `--overrides '{"alphaEnabled":true}'`.
 - `npx hardhat identity-registry:set-config --network <network> --execute --from 0xOwner` aligns the ENS wiring with
   repository defaults and overrides, writes optional Safe-ready JSON plans via `--plan-out`, enforces owner checks before
@@ -179,6 +179,29 @@ Edit configuration files under `config/` to match the deployment environment:
   dry runs that confirm the current state and emit calldata plans before any transaction is sent.
 - `npx hardhat stake-manager:emergency-release --network <network> --account 0xWorker --amount <raw>` helps governance unlock
   specific worker balances with Safe-ready summaries and optional live broadcasts via `--execute --from 0xOwner`.
+
+### DisputeModule Hardhat tasks
+
+- `npx hardhat dispute-module:status --network <network>` surfaces the current owner, authorized JobRegistry, and pause state
+  as either console output or machine-readable JSON when `--json` is supplied.
+- `npx hardhat dispute-module:set-registry --network <network> --registry 0xRegistry` plans the initial registry wiring with a
+  Safe-ready payload (`--plan-out ./plan.json`) and enforces owner checks before allowing a broadcast via `--execute --from
+  0xOwner`.
+- `npx hardhat dispute-module:update-registry --network <network> --registry 0xNew --execute --from 0xOwner` validates that the
+  module is paused, highlights the previous/next registry, and emits a Safe-ready summary before calling
+  `updateJobRegistry`.
+- `npx hardhat dispute-module:pause --network <network>` and `npx hardhat dispute-module:unpause --network <network>` default
+  to dry runs that include encoded calldata, optional plan exports, and guardrails that avoid reverting when the module is
+  already in the desired state.
+
+### ValidationModule Hardhat tasks
+
+- `npx hardhat validation-module:status --network <network> --rules 'ruleA,ruleB'` reports the owner and the enabled state of
+  specific rules. Provide `--rules @./rules.json` or a JSON array (`--rules '["agents","jobs"]'`) to load identifiers from a
+  file or automation pipeline.
+- `npx hardhat validation-module:set-rule --network <network> --rule agents --enabled true` produces a Safe-ready plan with
+  current/next state metadata. Append `--plan-out ./plan.json` to export the payload, `--execute --from 0xOwner` to broadcast,
+  and `--force` when you need to emit calldata even if the rule already matches the requested state.
 
 ### IdentityRegistry ENS console
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,9 @@ require('solidity-coverage');
 require('./tasks/jobRegistry');
 require('./tasks/feePool');
 require('./tasks/stakeManager');
+require('./tasks/identityRegistry');
+require('./tasks/disputeModule');
+require('./tasks/validationModule');
 
 const { MNEMONIC, RPC_SEPOLIA, RPC_MAINNET } = process.env;
 

--- a/tasks/disputeModule.js
+++ b/tasks/disputeModule.js
@@ -1,0 +1,270 @@
+'use strict';
+
+const { task, types } = require('hardhat/config');
+
+const {
+  buildCallSummary,
+  ensureAddress,
+  ensureOwner,
+  formatAddress,
+  maybeWriteSummary,
+  printPlanSummary,
+  resolveSender,
+  toChecksum,
+} = require('../scripts/lib/owner-task-utils');
+
+async function resolveDisputeModule(hre, explicitAddress) {
+  const DisputeModule = hre.artifacts.require('DisputeModule');
+  if (explicitAddress) {
+    return DisputeModule.at(explicitAddress);
+  }
+  return DisputeModule.deployed();
+}
+
+function describeNetwork(hre) {
+  return (hre.network && hre.network.name) || 'unknown';
+}
+
+function buildStatusSummary({ hre, disputeModule, owner, jobRegistry, paused }) {
+  return {
+    network: describeNetwork(hre),
+    disputeModule: toChecksum(hre.web3, disputeModule.address),
+    owner: toChecksum(hre.web3, owner),
+    jobRegistry: toChecksum(hre.web3, jobRegistry),
+    paused: Boolean(paused),
+  };
+}
+
+function printStatus(summary, hre) {
+  console.log(`DisputeModule status on ${summary.network}:`);
+  console.log(`- Address: ${formatAddress(hre.web3, summary.disputeModule)}`);
+  console.log(`- Owner: ${formatAddress(hre.web3, summary.owner)}`);
+  console.log(`- Job registry: ${formatAddress(hre.web3, summary.jobRegistry)}`);
+  console.log(`- Paused: ${summary.paused ? 'yes' : 'no'}`);
+}
+
+task('dispute-module:status', 'Inspect DisputeModule ownership, wiring, and pause state')
+  .addOptionalParam('dispute', 'Address of the DisputeModule contract', undefined, types.string)
+  .addFlag('json', 'Emit the summary as JSON for automation pipelines')
+  .setAction(async (args, hre) => {
+    const disputeModule = await resolveDisputeModule(hre, args.dispute);
+    const [owner, jobRegistry, paused] = await Promise.all([
+      disputeModule.owner(),
+      disputeModule.jobRegistry(),
+      disputeModule.paused(),
+    ]);
+
+    const summary = buildStatusSummary({ hre, disputeModule, owner, jobRegistry, paused });
+
+    if (args.json) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    printStatus(summary, hre);
+  });
+
+task('dispute-module:set-registry', 'Initializes the JobRegistry authorized to raise disputes')
+  .addOptionalParam('dispute', 'Address of the DisputeModule contract', undefined, types.string)
+  .addParam('registry', 'Address of the JobRegistry contract', undefined, types.string)
+  .addOptionalParam('from', 'Sender address (defaults to the first unlocked account)', undefined, types.string)
+  .addOptionalParam('planOut', 'Optional path to write a Safe-ready summary JSON', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transaction after confirmation')
+  .setAction(async (args, hre) => {
+    const disputeModule = await resolveDisputeModule(hre, args.dispute);
+    const owner = await disputeModule.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'DisputeModule');
+
+    const registryAddress = ensureAddress(hre.web3, args.registry, '--registry');
+    const currentRegistry = await disputeModule.jobRegistry();
+    if (currentRegistry && currentRegistry !== '0x0000000000000000000000000000000000000000') {
+      throw new Error(
+        `DisputeModule already has a job registry configured (${currentRegistry}). Use dispute-module:update-registry instead.`,
+      );
+    }
+
+    const callData = disputeModule.contract.methods.setJobRegistry(registryAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'dispute-module:setJobRegistry',
+      method: 'setJobRegistry(address)',
+      args: [registryAddress],
+      metadata: {
+        previousRegistry: currentRegistry || null,
+        newRegistry: registryAddress,
+      },
+      contractAddress: disputeModule.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await disputeModule.setJobRegistry(registryAddress, { from: sender });
+    console.log(`Transaction submitted. DisputeModule job registry set to ${registryAddress}.`);
+  });
+
+task('dispute-module:update-registry', 'Reassigns the JobRegistry authorized to report disputes')
+  .addOptionalParam('dispute', 'Address of the DisputeModule contract', undefined, types.string)
+  .addParam('registry', 'Address of the new JobRegistry contract', undefined, types.string)
+  .addOptionalParam('from', 'Sender address (defaults to the first unlocked account)', undefined, types.string)
+  .addOptionalParam('planOut', 'Optional path to write a Safe-ready summary JSON', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transaction after confirmation')
+  .setAction(async (args, hre) => {
+    const disputeModule = await resolveDisputeModule(hre, args.dispute);
+    const owner = await disputeModule.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'DisputeModule');
+
+    const paused = await disputeModule.paused();
+    if (!paused) {
+      throw new Error('DisputeModule must be paused before updating the job registry. Run dispute-module:pause first.');
+    }
+
+    const currentRegistry = await disputeModule.jobRegistry();
+    if (!currentRegistry || currentRegistry === '0x0000000000000000000000000000000000000000') {
+      throw new Error('DisputeModule job registry has not been initialized. Use dispute-module:set-registry instead.');
+    }
+
+    const registryAddress = ensureAddress(hre.web3, args.registry, '--registry');
+    if (currentRegistry.toLowerCase() === registryAddress.toLowerCase()) {
+      throw new Error('The provided registry address matches the current configuration.');
+    }
+
+    const callData = disputeModule.contract.methods.updateJobRegistry(registryAddress).encodeABI();
+    const plan = buildCallSummary({
+      action: 'dispute-module:updateJobRegistry',
+      method: 'updateJobRegistry(address)',
+      args: [registryAddress],
+      metadata: {
+        previousRegistry: currentRegistry,
+        newRegistry: registryAddress,
+        paused: true,
+      },
+      contractAddress: disputeModule.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    await disputeModule.updateJobRegistry(registryAddress, { from: sender });
+    console.log(`Transaction submitted. DisputeModule job registry updated to ${registryAddress}.`);
+  });
+
+task('dispute-module:pause', 'Pauses dispute lifecycle event forwarding')
+  .addOptionalParam('dispute', 'Address of the DisputeModule contract', undefined, types.string)
+  .addOptionalParam('from', 'Sender address (defaults to the first unlocked account)', undefined, types.string)
+  .addOptionalParam('planOut', 'Optional path to write a Safe-ready summary JSON', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transaction after confirmation')
+  .setAction(async (args, hre) => {
+    const disputeModule = await resolveDisputeModule(hre, args.dispute);
+    const owner = await disputeModule.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'DisputeModule');
+
+    const paused = await disputeModule.paused();
+    if (paused) {
+      console.log('DisputeModule is already paused. No transaction required.');
+      return;
+    }
+
+    const callData = disputeModule.contract.methods.pause().encodeABI();
+    const plan = buildCallSummary({
+      action: 'dispute-module:pause',
+      method: 'pause()',
+      args: [],
+      metadata: {
+        previousPaused: paused,
+        nextPaused: true,
+      },
+      contractAddress: disputeModule.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    const receipt = await disputeModule.pause({ from: sender });
+    console.log('Transaction submitted. DisputeModule paused.');
+    if (receipt && (receipt.tx || receipt.transactionHash)) {
+      console.log(`Tx hash: ${receipt.tx || receipt.transactionHash}`);
+    }
+  });
+
+task('dispute-module:unpause', 'Resumes dispute lifecycle event forwarding')
+  .addOptionalParam('dispute', 'Address of the DisputeModule contract', undefined, types.string)
+  .addOptionalParam('from', 'Sender address (defaults to the first unlocked account)', undefined, types.string)
+  .addOptionalParam('planOut', 'Optional path to write a Safe-ready summary JSON', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transaction after confirmation')
+  .setAction(async (args, hre) => {
+    const disputeModule = await resolveDisputeModule(hre, args.dispute);
+    const owner = await disputeModule.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'DisputeModule');
+
+    const paused = await disputeModule.paused();
+    if (!paused) {
+      console.log('DisputeModule is already unpaused. No transaction required.');
+      return;
+    }
+
+    const callData = disputeModule.contract.methods.unpause().encodeABI();
+    const plan = buildCallSummary({
+      action: 'dispute-module:unpause',
+      method: 'unpause()',
+      args: [],
+      metadata: {
+        previousPaused: paused,
+        nextPaused: false,
+      },
+      contractAddress: disputeModule.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    const receipt = await disputeModule.unpause({ from: sender });
+    console.log('Transaction submitted. DisputeModule unpaused.');
+    if (receipt && (receipt.tx || receipt.transactionHash)) {
+      console.log(`Tx hash: ${receipt.tx || receipt.transactionHash}`);
+    }
+  });
+

--- a/tasks/identityRegistry.js
+++ b/tasks/identityRegistry.js
@@ -117,7 +117,7 @@ function resolveVariantWithWarning(candidate) {
 
 task('identity-registry:status', 'Inspect IdentityRegistry ENS configuration and optional drift against config files')
   .addOptionalParam('identity', 'IdentityRegistry contract address', undefined, types.string)
-  .addOptionalParam('config', 'Explicit ENS config file path', undefined, types.string)
+  .addOptionalParam('configPath', 'Explicit ENS config file path', undefined, types.string)
   .addOptionalParam('variant', 'Config variant hint (mainnet, sepolia, dev)', undefined, types.string)
   .addOptionalParam(
     'overrides',
@@ -134,7 +134,8 @@ task('identity-registry:status', 'Inspect IdentityRegistry ENS configuration and
     const networkName = hre.network && hre.network.name ? hre.network.name : '(unspecified)';
     const variantHint = args.variant || networkName || undefined;
     const resolvedVariant = resolveVariantWithWarning(variantHint);
-    const variantForConfig = args.config ? null : resolvedVariant || args.variant || networkName || undefined;
+    const explicitConfigPath = args.configPath || null;
+    const variantForConfig = explicitConfigPath ? null : resolvedVariant || args.variant || networkName || undefined;
 
     console.log('AGIJobsv1 — IdentityRegistry Hardhat console');
     console.log('Action: status');
@@ -150,8 +151,8 @@ task('identity-registry:status', 'Inspect IdentityRegistry ENS configuration and
 
     try {
       const configProfile = loadEnsConfig({
-        explicitPath: args.config,
-        variant: args.config ? undefined : variantForConfig,
+        explicitPath: explicitConfigPath,
+        variant: explicitConfigPath ? undefined : variantForConfig,
       });
       console.log(`Config file: ${configProfile.path}`);
       const plan = buildSetPlan({ current, baseConfig: configProfile.values, overrides });
@@ -170,7 +171,7 @@ task('identity-registry:status', 'Inspect IdentityRegistry ENS configuration and
 task('identity-registry:set-config', 'Align IdentityRegistry ENS configuration with repository defaults and optional overrides')
   .addOptionalParam('identity', 'IdentityRegistry contract address', undefined, types.string)
   .addOptionalParam('from', 'Sender address (defaults to first unlocked account)', undefined, types.string)
-  .addOptionalParam('config', 'Explicit ENS config file path', undefined, types.string)
+  .addOptionalParam('configPath', 'Explicit ENS config file path', undefined, types.string)
   .addOptionalParam('variant', 'Config variant hint (mainnet, sepolia, dev)', undefined, types.string)
   .addOptionalParam(
     'overrides',
@@ -190,7 +191,8 @@ task('identity-registry:set-config', 'Align IdentityRegistry ENS configuration w
     const networkName = hre.network && hre.network.name ? hre.network.name : '(unspecified)';
     const variantHint = args.variant || networkName || undefined;
     const resolvedVariant = resolveVariantWithWarning(variantHint);
-    const variantForConfig = args.config ? null : resolvedVariant || args.variant || networkName || undefined;
+    const explicitConfigPath = args.configPath || null;
+    const variantForConfig = explicitConfigPath ? null : resolvedVariant || args.variant || networkName || undefined;
 
     console.log('AGIJobsv1 — IdentityRegistry Hardhat console');
     console.log('Action: set-config');
@@ -208,8 +210,8 @@ task('identity-registry:set-config', 'Align IdentityRegistry ENS configuration w
     let configProfile;
     try {
       configProfile = loadEnsConfig({
-        explicitPath: args.config,
-        variant: args.config ? undefined : variantForConfig,
+        explicitPath: explicitConfigPath,
+        variant: explicitConfigPath ? undefined : variantForConfig,
       });
     } catch (error) {
       const message = error && error.message ? error.message : String(error);

--- a/tasks/validationModule.js
+++ b/tasks/validationModule.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { task, types } = require('hardhat/config');
+
+const {
+  buildCallSummary,
+  ensureOwner,
+  formatAddress,
+  maybeWriteSummary,
+  printPlanSummary,
+  resolveSender,
+  toChecksum,
+} = require('../scripts/lib/owner-task-utils');
+
+function describeNetwork(hre) {
+  return (hre.network && hre.network.name) || 'unknown';
+}
+
+async function resolveValidationModule(hre, explicitAddress) {
+  const ValidationModule = hre.artifacts.require('ValidationModule');
+  if (explicitAddress) {
+    return ValidationModule.at(explicitAddress);
+  }
+  return ValidationModule.deployed();
+}
+
+function normalizeRule(web3, rawInput) {
+  const value = String(rawInput || '').trim();
+  if (!value) {
+    throw new Error('Validation rule identifier is required.');
+  }
+
+  if (/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    return { hash: value, description: null, source: rawInput };
+  }
+
+  const hash = web3.utils.keccak256(value);
+  return {
+    hash,
+    description: `keccak256('${value}')`,
+    source: rawInput,
+  };
+}
+
+function parseRuleEntries(rawContent, contextLabel) {
+  if (!rawContent) {
+    return [];
+  }
+
+  const trimmed = rawContent.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed.map((entry) => String(entry).trim()).filter(Boolean);
+    }
+    return [String(parsed).trim()].filter(Boolean);
+  } catch (error) {
+    const segments = trimmed
+      .split(/[\r\n,]+/)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+
+    if (segments.length === 0) {
+      throw new Error(
+        contextLabel
+          ? `No rule identifiers found in ${contextLabel}. Provide a JSON array or comma/newline-separated values.`
+          : 'No rule identifiers found. Provide a JSON array or comma/newline-separated values.',
+      );
+    }
+
+    return segments;
+  }
+}
+
+function resolveRuleInputs(raw, baseDir = process.cwd()) {
+  if (!raw) {
+    return [];
+  }
+
+  const trimmed = String(raw).trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed.startsWith('@')) {
+    const filePath = path.resolve(baseDir, trimmed.slice(1));
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Rules file not found at ${filePath}`);
+    }
+    const contents = fs.readFileSync(filePath, 'utf8');
+    return parseRuleEntries(contents, filePath);
+  }
+
+  return parseRuleEntries(trimmed, null);
+}
+
+function buildStatusSummary({ hre, validationModule, owner, ruleSummaries }) {
+  return {
+    network: describeNetwork(hre),
+    validationModule: toChecksum(hre.web3, validationModule.address),
+    owner: toChecksum(hre.web3, owner),
+    rules: ruleSummaries,
+  };
+}
+
+function printStatus(summary, hre) {
+  console.log(`ValidationModule status on ${summary.network}:`);
+  console.log(`- Address: ${formatAddress(hre.web3, summary.validationModule)}`);
+  console.log(`- Owner: ${formatAddress(hre.web3, summary.owner)}`);
+  if (!summary.rules || summary.rules.length === 0) {
+    console.log('- Rules: (provide --rules to inspect specific identifiers)');
+    return;
+  }
+
+  console.log('- Rules:');
+  summary.rules.forEach((rule) => {
+    const label = rule.description ? `${rule.hash} (${rule.description})` : rule.hash;
+    console.log(`  • ${label} — ${rule.enabled ? 'enabled' : 'disabled'}`);
+  });
+}
+
+task('validation-module:status', 'Inspect ValidationModule ownership and optional rule states')
+  .addOptionalParam('validation', 'Address of the ValidationModule contract', undefined, types.string)
+  .addOptionalParam(
+    'rules',
+    'Comma-separated list, JSON array, or @path file reference of rule identifiers to inspect',
+    undefined,
+    types.string,
+  )
+  .addFlag('json', 'Emit the summary as JSON for automation pipelines')
+  .setAction(async (args, hre) => {
+    const validationModule = await resolveValidationModule(hre, args.validation);
+    const owner = await validationModule.owner();
+
+    const ruleInputs = resolveRuleInputs(args.rules);
+    const ruleSummaries = [];
+    for (const ruleInput of ruleInputs) {
+      const rule = normalizeRule(hre.web3, ruleInput);
+      const enabled = await validationModule.validationRules(rule.hash);
+      ruleSummaries.push({
+        input: String(ruleInput),
+        hash: rule.hash,
+        description: rule.description,
+        enabled: Boolean(enabled),
+      });
+    }
+
+    const summary = buildStatusSummary({ hre, validationModule, owner, ruleSummaries });
+
+    if (args.json) {
+      console.log(JSON.stringify(summary, null, 2));
+      return;
+    }
+
+    printStatus(summary, hre);
+  });
+
+task('validation-module:set-rule', 'Enables or disables a validation rule with Safe-ready planning support')
+  .addOptionalParam('validation', 'Address of the ValidationModule contract', undefined, types.string)
+  .addParam('rule', 'Rule identifier (bytes32 hash or human-readable string)', undefined, types.string)
+  .addParam('enabled', 'Whether the rule should be enabled', undefined, types.boolean)
+  .addOptionalParam('from', 'Sender address (defaults to the first unlocked account)', undefined, types.string)
+  .addOptionalParam('planOut', 'Optional path to write a Safe-ready summary JSON', undefined, types.string)
+  .addFlag('execute', 'Broadcast the transaction after confirmation')
+  .addFlag('force', 'Allow broadcasting even if the desired state matches the current rule value')
+  .setAction(async (args, hre) => {
+    const validationModule = await resolveValidationModule(hre, args.validation);
+    const owner = await validationModule.owner();
+    const sender = await resolveSender(hre, args.from);
+    ensureOwner(sender, owner, 'ValidationModule');
+
+    const rule = normalizeRule(hre.web3, args.rule);
+    const desiredEnabled = Boolean(args.enabled);
+    const current = await validationModule.validationRules(rule.hash);
+    const currentEnabled = Boolean(current);
+
+    if (!args.force && currentEnabled === desiredEnabled) {
+      console.log(
+        `Validation rule ${rule.hash} already matches the desired state (${desiredEnabled ? 'enabled' : 'disabled'}). ` +
+          'No transaction required. Re-run with --force to generate a plan anyway.',
+      );
+      return;
+    }
+
+    const callData = validationModule.contract.methods
+      .setValidationRule(rule.hash, desiredEnabled)
+      .encodeABI();
+    const plan = buildCallSummary({
+      action: 'validation-module:setValidationRule',
+      method: 'setValidationRule(bytes32,bool)',
+      args: [rule.hash, desiredEnabled],
+      metadata: {
+        ruleInput: String(args.rule),
+        description: rule.description,
+        previousEnabled: currentEnabled,
+        nextEnabled: desiredEnabled,
+      },
+      contractAddress: validationModule.address,
+      sender,
+      callData,
+    });
+
+    printPlanSummary(plan);
+    const writtenPath = maybeWriteSummary(args.planOut, plan);
+    if (writtenPath) {
+      console.log(`Plan summary written to ${writtenPath}`);
+    }
+
+    if (!args.execute) {
+      console.log('Dry run complete — re-run with --execute to broadcast the transaction.');
+      return;
+    }
+
+    const receipt = await validationModule.setValidationRule(rule.hash, desiredEnabled, { from: sender });
+    console.log(
+      `Transaction submitted. Validation rule ${rule.hash} now ${desiredEnabled ? 'enabled' : 'disabled'}.`,
+    );
+    if (receipt && (receipt.tx || receipt.transactionHash)) {
+      console.log(`Tx hash: ${receipt.tx || receipt.transactionHash}`);
+    }
+  });
+


### PR DESCRIPTION
## Summary
- load the identity, dispute, and validation task definitions automatically in the Hardhat config so CLI commands are available without manual imports
- add a full dispute-module Hardhat task suite covering status, registry wiring, and pause management with Safe-ready plan exports and owner safeguards
- add validation-module management tasks that normalize rule identifiers (including file-based lists), emit Safe-ready payloads, and refuse no-op broadcasts without --force while updating docs/changelog accordingly
- switch the identity-registry task flag to --config-path to avoid Hardhat conflicts and document the new workflows

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4189f49608333936db9653cb387ab