### PR TITLE
Expand IdentityRegistry alpha alias controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ Edit configuration files under `config/` to match the deployment environment:
   multisig or custom signing flow before toggling `--execute`.
 - CLI overrides accept ENS names (`--ens.agentRoot`) or pre-computed hashes (`--ens.agentRootHash`), making it simple to
   flip `alphaEnabled` with the correct root hash without editing JSON by hand.
+- The console now surfaces the `alphaAgent` alias configuration so `alpha.agent.agi.eth` and the base `agent.agi.eth`
+  namespace can be kept in sync. Provide `--ens.alphaAgentRoot` / `--ens.alphaAgentRootHash` to override the derived
+  alias, or `--ens.alphaAgentEnabled=false` to temporarily suspend the wildcard while keeping the primary agent root
+  intact.
 
 ### IdentityRegistry emergency console
 

--- a/config/ens.dev.json
+++ b/config/ens.dev.json
@@ -5,6 +5,9 @@
   "clubRoot": null,
   "agentRootHash": null,
   "clubRootHash": null,
+  "alphaAgentRoot": null,
+  "alphaAgentRootHash": null,
+  "alphaAgentEnabled": false,
   "alphaClubRoot": null,
   "alphaClubRootHash": null,
   "alphaEnabled": false

--- a/config/ens.mainnet.json
+++ b/config/ens.mainnet.json
@@ -5,6 +5,9 @@
   "clubRoot": "club.agi.eth",
   "agentRootHash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
   "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+  "alphaAgentRoot": "alpha.agent.agi.eth",
+  "alphaAgentRootHash": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e",
+  "alphaAgentEnabled": true,
   "alphaClubRoot": "alpha.club.agi.eth",
   "alphaClubRootHash": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e",
   "alphaEnabled": false

--- a/config/ens.sepolia.json
+++ b/config/ens.sepolia.json
@@ -5,6 +5,9 @@
   "clubRoot": "club.agi.eth",
   "agentRootHash": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
   "clubRootHash": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+  "alphaAgentRoot": "alpha.agent.agi.eth",
+  "alphaAgentRootHash": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e",
+  "alphaAgentEnabled": true,
   "alphaClubRoot": "alpha.club.agi.eth",
   "alphaClubRootHash": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e",
   "alphaEnabled": false

--- a/scripts/compute-namehash.js
+++ b/scripts/compute-namehash.js
@@ -69,6 +69,7 @@ const assignHash = (rootKey, hashKey) => {
 assignHash('agentRoot', 'agentRootHash');
 assignHash('clubRoot', 'clubRootHash');
 assignHash('alphaClubRoot', 'alphaClubRootHash');
+assignHash('alphaAgentRoot', 'alphaAgentRootHash');
 
 fs.writeFileSync(targetPath, `${JSON.stringify(config, null, 2)}\n`);
 console.log(`Updated ENS namehashes in ${targetPath}`);


### PR DESCRIPTION
## Summary
- persist the alpha agent ENS alias in IdentityRegistry with owner-level controls and events
- enrich ENS config files, CLI tooling, and documentation to surface the alpha agent namespace
- extend unit tests and Hardhat tasks to validate the alias workflow and keep scripts in sync

## Testing
- npm run lint:sol
- npm test
- npm run namehash:mainnet

------
https://chatgpt.com/codex/tasks/task_e_68d4379f159c8333bcb3164cc562353c