### PR TITLE
Sync alpha club alias with club root updates

### DIFF
--- a/contracts/core/IdentityRegistry.sol
+++ b/contracts/core/IdentityRegistry.sol
@@ -108,6 +108,7 @@ contract IdentityRegistry is Ownable {
     function setClubRootHash(bytes32 clubHash) external onlyOwner {
         require(clubHash != bytes32(0), "IdentityRegistry: club hash");
         clubRootHash = clubHash;
+        _syncAlphaClubRoot(clubHash);
         emit ClubRootHashUpdated(clubHash);
     }
 
@@ -274,6 +275,21 @@ contract IdentityRegistry is Ownable {
         alphaAgentRootHash = alphaAgentHash;
         alphaAgentEnabled = enabled;
         emit AlphaAgentConfigured(alphaAgentHash, enabled);
+    }
+
+    function _syncAlphaClubRoot(bytes32 clubHash) private {
+        bytes32 currentAlpha = alphaClubRootHash;
+        if (currentAlpha == bytes32(0)) {
+            return;
+        }
+
+        bytes32 derivedAlpha = _deriveAlphaClubRoot(clubHash);
+        if (derivedAlpha == currentAlpha) {
+            return;
+        }
+
+        alphaClubRootHash = derivedAlpha;
+        emit AlphaClubConfigured(derivedAlpha, alphaEnabled);
     }
 
     function _ownsNode(address account, bytes32 node) private view returns (bool) {

--- a/test/identityRegistry.test.js
+++ b/test/identityRegistry.test.js
@@ -234,6 +234,28 @@ contract('IdentityRegistry', (accounts) => {
     );
   });
 
+  it('keeps the alpha club alias synchronized when updating the club root', async function () {
+    const agent = web3.utils.keccak256('agent-root');
+    const club = web3.utils.keccak256('club-root');
+    const alphaLabel = web3.utils.keccak256('alpha');
+    const alphaClub = web3.utils.soliditySha3(
+      { type: 'bytes32', value: club },
+      { type: 'bytes32', value: alphaLabel }
+    );
+    const updatedClub = web3.utils.keccak256('updated-club-root');
+    const updatedAlphaClub = web3.utils.soliditySha3(
+      { type: 'bytes32', value: updatedClub },
+      { type: 'bytes32', value: alphaLabel }
+    );
+
+    await this.registry.configureEns(stranger, worker, agent, club, alphaClub, true, { from: owner });
+
+    await this.registry.setClubRootHash(updatedClub, { from: owner });
+    assert.strictEqual(await this.registry.clubRootHash(), updatedClub);
+    assert.strictEqual(await this.registry.alphaClubRootHash(), updatedAlphaClub);
+    assert.isTrue(await this.registry.alphaEnabled());
+  });
+
   it('allows the owner to configure the alpha club root and toggle', async function () {
     const agent = web3.utils.keccak256('agent-root');
     const club = web3.utils.keccak256('club-root');


### PR DESCRIPTION
## Summary
- update `IdentityRegistry` to recalculate the alpha club alias whenever the club root hash is rotated so the namespaces stay equivalent
- add a regression test that validates the alpha club hash and toggle remain aligned after club root updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4a00c0a588333a0ec78757763db66