### PR TITLE
docs: enrich mainnet playbook with diagrams and checklists

### DIFF
--- a/docs/deployment/mainnet-truffle-playbook.md
+++ b/docs/deployment/mainnet-truffle-playbook.md
@@ -7,6 +7,66 @@ designed to be checklist-driven so that each step is auditable and repeatable by
 > **TL;DR** – run `npm run deploy:checklist`, rehearse on Sepolia, then execute `npm run migrate:mainnet`
 > once every preflight item is green.
 
+## 0. Visual map of the protocol
+
+Understanding how contracts relate to each other dramatically simplifies pre-deployment reviews and
+incident response. The diagram below highlights the production topology after the migrations finish.
+
+```mermaid
+graph TD
+  subgraph Governance Multisig / Timelock
+    GOV[Owner]
+  end
+
+  GOV -->|owns| JR[JobRegistry]
+  GOV -->|owns| SM[StakeManager]
+  GOV -->|owns| FP[FeePool]
+  GOV -->|owns| IR[IdentityRegistry]
+  GOV -->|owns| DM[DisputeModule]
+  GOV -->|owns| VM[ValidationModule]
+  GOV -->|owns| RE[ReputationEngine]
+  GOV -->|owns| CNFT[CertificateNFT]
+
+  JR -->|pulls stake data| SM
+  JR -->|credits fees| FP
+  JR -->|identity checks| IR
+  JR -->|reputation updates| RE
+  JR -->|dispute escalation| DM
+  JR -->|validation oracle| VM
+  IR -->|optional ENS wiring| ENS[(ENS Registry)]
+
+  style GOV fill:#ffd54f,stroke:#f57f17,stroke-width:2px
+  style JR fill:#e1f5fe,stroke:#0288d1
+  style SM fill:#fbe9e7,stroke:#d84315
+  style FP fill:#f3e5f5,stroke:#6a1b9a
+  style IR fill:#f1f8e9,stroke:#558b2f
+  style DM fill:#fff8e1,stroke:#ff8f00
+  style VM fill:#ede7f6,stroke:#4527a0
+  style RE fill:#e8f5e9,stroke:#2e7d32
+  style CNFT fill:#fff3e0,stroke:#ef6c00
+```
+
+## Deployment flywheel at a glance
+
+```mermaid
+sequenceDiagram
+    participant Ops as Operations Team
+    participant CLI as Local CLI
+    participant Chain as Ethereum Mainnet
+    participant Docs as Runbook / Logs
+    Ops->>CLI: 1. npm run deploy:checklist
+    CLI->>Ops: Validated environment + config snapshot
+    Ops->>CLI: 2. npm run build && npm run migrate:sepolia (rehearsal)
+    CLI->>Docs: Archive rehearsal receipts
+    Ops->>CLI: 3. npm run migrate:mainnet
+    CLI->>Chain: Broadcast migrations 1-5
+    Chain-->>CLI: Transaction receipts
+    CLI->>Docs: Capture addresses & outputs
+    Ops->>CLI: 4. npm run owner:wizard -- NETWORK=mainnet
+    CLI->>Chain: Optional post-deploy adjustments
+    Ops->>Docs: File final governance dossier
+```
+
 ## 1. Prerequisites
 
 | Requirement | Why it matters |
@@ -22,7 +82,8 @@ designed to be checklist-driven so that each step is auditable and repeatable by
 
 ### Files to review and customize
 
-All configuration lives in JSON files under `config/`:
+All configuration lives in JSON files under `config/`. Think of these files as the single source of
+truth that back every migration and owner script:
 
 * `config/agialpha.mainnet.json` – staking token address, decimals, burn address, metadata.
 * `config/ens.mainnet.json` – ENS registry + name wrapper addresses and root namehashes.
@@ -31,7 +92,9 @@ All configuration lives in JSON files under `config/`:
   across networks.
 
 The repository ships with canonical production defaults. Only change these values with
-multi-stakeholder approval and re-run the validation script after every edit.
+multi-stakeholder approval and re-run the validation script after every edit. The checklist command
+prints the active configuration so the entire operations team can visually diff any changes before
+sign-off.
 
 ## 2. Prepare the environment
 
@@ -49,7 +112,11 @@ multi-stakeholder approval and re-run the validation script after every edit.
    TIMELOCK_ADDR="0xOperationsTimelock"
    ```
 4. Never paste the mnemonic in plain text terminals. Use a secure shell with history disabled or
-   rely on environment managers such as `direnv`.
+   rely on environment managers such as `direnv`. Hardware wallets are strongly recommended for the
+   production broadcast step.
+
+> **Tip:** run `npm run diagnose` at any point to print RPC reachability, ENS settings, configured
+> networks, and contract wiring diagnostics without touching the blockchain.
 
 ## 3. Run the automated preflight checklist
 
@@ -73,6 +140,9 @@ Resolve any red ✖ markers before moving forward. You can pass another variant 
 npm run deploy:checklist -- sepolia
 ```
 
+If anything fails, the script exits with a non-zero status so CI/CD pipelines can gate releases
+automatically. Capture the full console output in your deployment dossier.
+
 ## 4. Compile and rehearse on Sepolia (recommended)
 
 1. `npm run build`
@@ -87,11 +157,13 @@ as the formal dress rehearsal and lets the owner practice the governance tooling
 
 With all rehearsals complete and approvals in place:
 
-1. **Final validation** – run `npm run deploy:checklist` once more to confirm the environment.
-2. **Compile** – `npm run build`
-3. **Deploy** – `npm run migrate:mainnet`
-4. **Sanity check** – `npm run wire:verify -- NETWORK=mainnet`
-5. **Ownership audit** – `npm run owner:wizard -- NETWORK=mainnet`
+| Step | Command | Purpose |
+| --- | --- | --- |
+| 1 | `npm run deploy:checklist` | Ensure env + configs are still valid. |
+| 2 | `npm run build` | Produce Solidity artifacts using the audited compiler version. |
+| 3 | `npm run migrate:mainnet` | Broadcast the full migration suite to Ethereum. |
+| 4 | `npm run wire:verify -- NETWORK=mainnet` | Confirm wiring matches config/params.json. |
+| 5 | `npm run owner:wizard -- NETWORK=mainnet` | Review ownership + optionally adjust parameters. |
 
 Truffle will execute the migrations in order:
 
@@ -107,6 +179,11 @@ Truffle will execute the migrations in order:
 Every migration emits clear console logs. Save them in the deployment dossier alongside the final
 `build/contracts/*.json` artifacts.
 
+> **Operational reminder:** When the deployment completes, immediately export the resulting
+> addresses via `npm run export:artifacts NETWORK=mainnet` and circulate them to downstream teams
+> (frontend, analytics, monitoring) so there is no lag in switching from rehearsal infrastructure to
+> production endpoints.
+
 ## 6. Post-deployment tasks
 
 1. **Verify sources** – `npm run verify:mainnet`
@@ -118,6 +195,31 @@ Every migration emits clear console logs. Save them in the deployment dossier al
 6. **Back up** – archive the `.env` file, deployment outputs, and governance approvals in secure
    storage.
 
+### Recommended observability wiring
+
+```mermaid
+flowchart LR
+  subgraph Monitoring Stack
+    A[Prometheus / Custom Indexer]
+    B[Grafana]
+    C[Alertmanager]
+  end
+
+  OnChain[(Ethereum RPC/Websocket)] -->|events| A
+  A --> B
+  A --> C
+  C -->|PagerDuty / Email / SMS| Team
+
+  Team -->|uses runbooks| Docs
+```
+
+Set up alerts for:
+
+- `JobRegistry` paused state changes or dispute spikes.
+- `StakeManager` total staked balance deviations.
+- `FeePool` accumulated fees and burn address withdrawals.
+- ENS configuration drifts (poll via `npm run wire:verify`).
+
 ## 7. Operational control surface (owner capabilities)
 
 The protocol is designed so the owner (multisig) can safely update or recover every critical
@@ -125,13 +227,13 @@ parameter:
 
 | Contract | Key functions | Purpose |
 | --- | --- | --- |
-| `JobRegistry` | `setModules`, `updateModule` | Swap Identity/Stake/Fee/Dispute modules as the platform evolves. |
-| | `setTimings`, `updateTiming` | Tune commit/reveal/dispute windows without redeploying. |
+| `JobRegistry` | `setFullConfiguration`, `setModules`, `updateModule` | Swap Identity/Stake/Fee/Dispute modules or update the entire wiring in a single transaction. |
+| | `setTimings`, `updateTiming`, `extendJobDeadlines` | Tune lifecycle windows globally or per job. |
 | | `setThresholds`, `updateThreshold` | Adjust quorum, fees, slashing and approval thresholds. |
-| | `extendJobDeadlines`, `finalizeJob`, `raiseDispute`, `resolveDispute`, `timeoutJob` | Manage live jobs and disputes. |
+| | `finalizeJob`, `raiseDispute`, `resolveDispute`, `timeoutJob` | Manage live jobs, disputes, and escalations. |
 | `StakeManager` | `updateJobRegistry`, `setFeeRecipient`, `emergencyRelease` | Migrate registries, rotate fee recipients, or recover user funds. |
-| `FeePool` | `updateJobRegistry`, `withdrawFees` | Redirect fee routing or evacuate pooled fees. |
-| `IdentityRegistry` | `configureEns`, `setValidationModule`, `setIdentityAdmin` | Maintain identity proofs and ENS integration. |
+| `FeePool` | `updateJobRegistry`, `withdrawFees`, `updateBurnAddress` | Redirect fee routing, evacuate pooled fees, or rotate the burn sink. |
+| `IdentityRegistry` | `configureEns`, `setEnsRegistry`, `setEnsNameWrapper`, `setIdentityAdmin` | Maintain identity proofs and ENS integration. |
 | `ReputationEngine` | `setJobRegistry`, `setEvaluator`, `batchAdjustReputation` | Maintain trust signals and respond to disputes. |
 | `DisputeModule` | `setJobRegistry`, `setArbiter`, `setSlashBps` | Update dispute authority and penalties. |
 | `ValidationModule` | `setJobRegistry`, `setValidator`, `setApprovalThreshold` | Adjust validation logic and quorum requirements. |
@@ -165,6 +267,7 @@ Always document the incident timeline, transactions, and the root-cause analysis
 * ✅ Monitoring alerts configured for stake balances, fee pool balances, and JobRegistry pauses.
 * ✅ ENS records updated and verified (if applicable).
 * ✅ Incident response runbook reviewed quarterly.
+* ✅ Owner console scripts rehearsed quarterly to ensure institutional muscle memory.
 
 Following this playbook ensures that even a non-technical operations team can execute a safe,
 repeatable, and auditable mainnet deployment.


### PR DESCRIPTION
## Summary
- expand the Ethereum mainnet Truffle playbook with system and deployment mermaid diagrams
- add table-driven execution steps, observability guidance, and operational reminders for non-technical owners
- document control-surface updates so ownership and monitoring expectations stay explicit

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d565ff0250833386c3f23add01bf7c